### PR TITLE
Rattachement compte

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -24,7 +24,7 @@ class SessionsController < Devise::SessionsController
 
   def create_with_token
     resource = User.find_by_authentication_token(params[:auth_token])
-    if resource.attached_at.nil? && resource
+    if resource && resource.attached_to.nil?
       sign_in :user, resource
       redirect_to after_sign_in_path_for(resource) and return
     else

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1632,10 +1632,12 @@ class UsersController < ApplicationController
 
     if @user_to_detach.save
 
+      DeviseMailer.confirmation_instructions(@user_to_detach, @user_to_detach.confirmation_token).deliver_later
+
       if params[:addFamilyLink]
         is_created = FamilyMemberUsers.addFamilyMemberWithConfirmation(
-          [ActiveSupport::HashWithIndifferentAccess.new(@user_to_detach.as_json.merge({link: params[:link], is_paying_for: params[:is_paying_for], is_legal_referent: params[:is_legal_referent]}))],
-          @old_parent_user,
+          [ActiveSupport::HashWithIndifferentAccess.new(@old_parent_user.as_json.merge({link: params[:link], is_paying_for: params[:is_paying_for], is_legal_referent: params[:is_legal_referent]}))],
+          @user_to_detach,
           Season.current,
           send_confirmation: true
         )

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1642,8 +1642,9 @@ class UsersController < ApplicationController
           send_confirmation: true
         )
 
-        if !is_created
-          render json: {message: "Le lien familial n'as pus être créer mais l'utilisateur à bien été détaché"}, status: :unprocessable_entity and return
+        unless is_created
+          render json: { message: "Le lien familial n'as pus être créer mais l'utilisateur à bien été détaché" }, status: :unprocessable_entity
+          return
         end
       end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1034,7 +1034,7 @@ class UsersController < ApplicationController
       methods: :family_links_with_user
     }
     render json: Users::SearchUser.new(params[:last_name], params[:first_name], nil, params[:season_id], nil, includes,
-                                       false).execute
+                                       false, params[:hideAttachedAccounts]).execute
   end
 
   def set_level
@@ -1602,6 +1602,21 @@ class UsersController < ApplicationController
     @user = User.find(params[:id])
 
     render json: { all_doc_consented: @user.consent_document_users }
+  end
+
+  def attach_users
+    @user = User.find(params[:id])
+
+    render json: {message: "compte de rattachement not found"}, status: :not_found and return if @user.nil?
+
+    (params[:users] || []).each do |u|
+      user = User.find(u[:id])
+      next if user.nil? || user.attached? || user.id == @user.id
+
+      user.attached_to = @user
+      user.email = u[:email]
+      user.save
+    end
   end
 
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1474,6 +1474,9 @@ class UsersController < ApplicationController
       family_users << current_user
     end
 
+    family_users += user.attached_accounts
+    family_users += [user.attached_to] if user.attached_to&.id == @current_user.id || (user.attached_to && @current_user.is_admin)
+
     @pre_application = jsonize_pre_application.call(pre_application_id)
 
     @family_users = []

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -42,10 +42,15 @@ class Ability
     # for all users :
     family_ids = user.family.uniq.pluck(:id)
     family_ids.append(user.id)
+
+    attached_account_ids = user.attached_accounts.pluck(:id)
+
     can :manage, User, id: user.id
     can :manage, User, id: family_ids
+    can :manage, User, id: attached_account_ids
     can :create, Payment, payable_id: user.id
     can :manage, ActivityApplication, user_id: family_ids
+    can :manage, ActivityApplication, user_id: attached_account_ids
     can :read, Planning, user: user
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -949,7 +949,7 @@ class User < ApplicationRecord
 
   def ensure_attached_account_has_no_password
     if attached_to.present?
-      self.encrypted_password = nil
+      self.encrypted_password = ""
       self.password = nil
       self.password_confirmation = nil
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -299,6 +299,7 @@ class User < ApplicationRecord
     payment_schedules.find_by(season_id: Season.current.id)
   end
 
+  # @return [Array<FamilyMemberUser>]
   def family_links(season = Season.current_apps_season)
     return [] if season.nil?
 

--- a/app/services/family_member_users.rb
+++ b/app/services/family_member_users.rb
@@ -36,13 +36,20 @@ module FamilyMemberUsers
     family&.each do |member|
       fmu = if member[:id]
              User.find(member[:id])
-           else
-             User.new
+            else
+              # on ne change pas le lien d'attachement ici...
+             User.new(
+               attached_to_id: member[:attach_to_user] ? user.id : nil,
+             )
            end
 
       #is_created ||= member[:id].nil?
 
-      fmu.email = member[:email]
+      fmu.email = if fmu.attached? && fmu.attached_to.email == user.email
+                    nil
+                  else
+                    member[:email]
+                  end
       fmu.first_name = member[:first_name]
       fmu.last_name = member[:last_name]
       fmu.birthday = member[:birthday]

--- a/app/services/family_member_users.rb
+++ b/app/services/family_member_users.rb
@@ -45,7 +45,7 @@ module FamilyMemberUsers
 
       #is_created ||= member[:id].nil?
 
-      fmu.email = if fmu.attached? && fmu.attached_to.email == user.email
+      fmu.email = if fmu.attached? && fmu.email == user.email
                     nil
                   else
                     member[:email]

--- a/app/services/users/search_user.rb
+++ b/app/services/users/search_user.rb
@@ -1,6 +1,6 @@
 module Users
   class SearchUser
-    def initialize(last_name, first_name, birthday, season_id, adherent_number, includes, exact_search = true)
+    def initialize(last_name, first_name, birthday, season_id, adherent_number, includes, exact_search = true, hide_attached_accounts = false)
       @last_name = last_name.strip.capitalize
       @first_name = first_name.strip.capitalize
       @birthday = birthday
@@ -8,6 +8,7 @@ module Users
       @season = season_id.nil? ? nil : Season.find(season_id)
       @includes = includes
       @exact_search = exact_search
+      @hide_attached_accounts = hide_attached_accounts
     end
 
     def execute
@@ -21,6 +22,7 @@ module Users
 
       users = users.where(birthday: @birthday) unless @birthday.nil?
       users = users.where(adherent_number: @adherent_number) unless @adherent_number.nil?
+      users = users.where(attached_to_id: nil) if @hide_attached_accounts
 
 
       users.map do |u|

--- a/app/views/users/_family.html.erb
+++ b/app/views/users/_family.html.erb
@@ -81,7 +81,7 @@
                         <% if @user.attached_accounts.where(id: m.id).any? %>
                         <div class="col-sm-2 lienFamilial border-right py-1" style="flex:1">
                           <h4> Rattachement </h4>
-                          <%= react_component("detachAccount", {user: m.as_json(methods: %i[family_links_with_user attached_to]) }) %>
+                          <%= react_component("detachAccount", {from: "family_link", user: m.as_json(methods: %i[family_links_with_user attached_to]) }) %>
                         </div>
                         <% end %>
                         <div class="col-sm-3 lienFamilial py-1" style="flex:1">
@@ -164,7 +164,7 @@
           <% if @current_user.is_admin or (@user.id == @current_user.id) %>
             <div class="col-sm lienFamilial" style="flex:1">
               <h4> Rattachement </h4>
-              <%= react_component("detachAccount", {user: attached_user.as_json(methods: %i[family_links_with_user attached_to]) }) %>
+              <%= react_component("detachAccount", {from: "attached_account", user: attached_user.as_json(methods: %i[family_links_with_user attached_to]) }) %>
             </div>
             <div class="col-sm profil border-left <%= @season.closing_date_for_applications >= DateTime.now ? "border-right" : "" %>" style="flex:1"->
               <h4 class="mt-3 mb-2"> Profil </h4>

--- a/app/views/users/_family.html.erb
+++ b/app/views/users/_family.html.erb
@@ -78,7 +78,7 @@
                     </div>
                     <%# if @current_user.is_admin or @current_user.is_teacher or (@user.id == @current_user.id) or (m.id == @current_user.id) %>
                     <% if @current_user.is_admin or (@user.id == @current_user.id) or (m.id == @current_user.id) %>
-                        <% if @user.attached_accounts.where(id: m.id).any? %>
+                        <% if @current_user.is_admin #or @user.attached_accounts.where(id: m.id).any? %>
                         <div class="col-sm-2 lienFamilial border-right py-1" style="flex:1">
                           <h4> Rattachement </h4>
                           <%= react_component("detachAccount", {from: "family_link", user: m.as_json(methods: %i[family_links_with_user attached_to]) }) %>
@@ -162,10 +162,12 @@
             </div>
           </div>
           <% if @current_user.is_admin or (@user.id == @current_user.id) %>
-            <div class="col-sm lienFamilial" style="flex:1">
-              <h4> Rattachement </h4>
-              <%= react_component("detachAccount", {from: "attached_account", user: attached_user.as_json(methods: %i[family_links_with_user attached_to]) }) %>
-            </div>
+            <% if @current_user.is_admin %>
+              <div class="col-sm lienFamilial" style="flex:1">
+                <h4> Rattachement </h4>
+                <%= react_component("detachAccount", {from: "attached_account", user: attached_user.as_json(methods: %i[family_links_with_user attached_to]) }) %>
+              </div>
+            <% end %>
             <div class="col-sm profil border-left <%= @season.closing_date_for_applications >= DateTime.now ? "border-right" : "" %>" style="flex:1"->
               <h4 class="mt-3 mb-2"> Profil </h4>
               <% if @user.id == @current_user.id || @current_user.is_admin || attached_user.id == @current_user %>

--- a/app/views/users/_family.html.erb
+++ b/app/views/users/_family.html.erb
@@ -148,7 +148,7 @@
 
     <% if @attached_account_to_show.any? %>
       <hr /><br/>
-      <h2 class="title-profile">Comptes rattachés :</h2>
+      <h2 class="title-profile">Utilisateurs rattachés :</h2>
 
       <% @attached_account_to_show.each do |attached_user| %>
         <div class="contact-thumb">

--- a/app/views/users/_family.html.erb
+++ b/app/views/users/_family.html.erb
@@ -48,7 +48,10 @@
                     <div class="col-sm" style="flex:1">
                         <div class="contact-info">
                             <h3><%= m.first_name %> <b><%= m.last_name %></b></h3>
-                            <span class="relation"><%= "#{m.display_family_link(@user, @season)} #{@user.genitive_first_name}" %></span>
+                            <span class="relation"><%= "#{m.display_family_link(@user, @season)} #{@user.genitive_first_name}" %></span><br/>
+                            <% if @user.attached_accounts.where(id: m.id).any? %>
+                              <span class="relation">Compte rattaché</span>
+                            <% end %>
                             <% m.telephones.each do |t| %>
                                 <p><%= t.label.nil? ? "" : t.label.capitalize %>: <%= t.number %></p>
                             <% end %>
@@ -93,9 +96,9 @@
                             <h4 class="mt-3 mb-2"> Profil </h4>
                             <% if !(m.id == @current_user.id) || @current_user.is_admin %>
                                 <%= link_to(user_path(m), class: "btn btn-primary btn-outline") do %>
-                                    
+
                                     <i class="fas fa-eye"></i> Voir
-                                    
+
                                 <% end %>
                                 <%= link_to edit_user_path(m.id), class: "btn btn-outline btn-primary m-2" do %>
                                     <i class="fas fa-edit"></i> Éditer
@@ -135,5 +138,49 @@
                 <% end %>
             </div>
         </div>
+    <% end %>
+
+    <% if @attached_account_to_show.any? %>
+      <hr /><br/>
+      <h2 class="title-profile">Comptes rattachés :</h2>
+
+      <% @attached_account_to_show.each do |attached_user| %>
+        <div class="contact-thumb">
+          <div class="col-sm" style="flex:1">
+            <div class="contact-info">
+              <h3><%= attached_user.first_name %> <b><%= attached_user.last_name %></b></h3>
+              <span class="relation">compte rattaché</span>
+              <% attached_user.telephones.each do |t| %>
+                <p><%= t.label.nil? ? "" : t.label.capitalize %>: <%= t.number %></p>
+              <% end %>
+            </div>
+          </div>
+          <% if @current_user.is_admin or (@user.id == @current_user.id) %>
+            <div class="col-sm profil border-left <%= @season.closing_date_for_applications >= DateTime.now ? "border-right" : "" %>" style="flex:1"->
+              <h4 class="mt-3 mb-2"> Profil </h4>
+              <% if !(@user.id == @current_user.id) || @current_user.is_admin %>
+                <%= link_to(user_path(attached_user), class: "btn btn-primary btn-outline") do %>
+
+                  <i class="fas fa-eye"></i> Voir
+
+                <% end %>
+                <%= link_to edit_user_path(attached_user.id), class: "btn btn-outline btn-primary m-2" do %>
+                  <i class="fas fa-edit"></i> Éditer
+                <% end %>
+              <% end %>
+            </div>
+            <% if Season.registration_opened %>
+              <div class="col-sm border-dark" style="flex: 1;">
+                <h4> Activités </h4>
+                <% if !(@user.id == @current_user.id) || @current_user.is_admin %>
+                  <%= link_to new_application_path(attached_user), class: "btn btn-primary" do %>
+                    <i class="fas fa-graduation-cap"></i> Pré-inscrire
+                  <% end %>
+                <% end %>
+              </div>
+            <% end %>
+          <% end %>
+        </div>
+      <% end %>
     <% end %>
 </div>

--- a/app/views/users/_family.html.erb
+++ b/app/views/users/_family.html.erb
@@ -164,9 +164,11 @@
                   <i class="fas fa-eye"></i> Voir
 
                 <% end %>
-                <%= link_to edit_user_path(attached_user.id), class: "btn btn-outline btn-primary m-2" do %>
+                <%= link_to edit_user_path(attached_user.id), class: "btn btn-outline btn-primary" do %>
                   <i class="fas fa-edit"></i> Éditer
                 <% end %>
+
+                <%= react_component("detachAccount", {user: attached_user.as_json(methods: %i[family_links_with_user attached_to]) }) %>
               <% end %>
             </div>
             <% if Season.registration_opened %>

--- a/app/views/users/_family.html.erb
+++ b/app/views/users/_family.html.erb
@@ -45,7 +45,7 @@
             </div>
             <% @user.family(@season).uniq.sort_by { |u| -2 * (u.family_link_with(@user, @season)&.is_to_call || false).to_i - (u.family_link_with(@user, @season)&.is_paying_for || false).to_i }.each do |m| %>
                 <div class="contact-thumb">
-                    <div class="col-sm" style="flex:1">
+                    <div class="col-sm-2 py-1" style="flex:1">
                         <div class="contact-info">
                             <h3><%= m.first_name %> <b><%= m.last_name %></b></h3>
                             <span class="relation"><%= "#{m.display_family_link(@user, @season)} #{@user.genitive_first_name}" %></span><br/>
@@ -78,7 +78,13 @@
                     </div>
                     <%# if @current_user.is_admin or @current_user.is_teacher or (@user.id == @current_user.id) or (m.id == @current_user.id) %>
                     <% if @current_user.is_admin or (@user.id == @current_user.id) or (m.id == @current_user.id) %>
-                        <div class="col-sm lienFamilial" style="flex:1">
+                        <% if @user.attached_accounts.where(id: m.id).any? %>
+                        <div class="col-sm-2 lienFamilial border-right py-1" style="flex:1">
+                          <h4> Rattachement </h4>
+                          <%= react_component("detachAccount", {user: m.as_json(methods: %i[family_links_with_user attached_to]) }) %>
+                        </div>
+                        <% end %>
+                        <div class="col-sm-3 lienFamilial py-1" style="flex:1">
                             <h4> Lien Familial </h4>
                                 <%= react_component("userForm/HandleFamilyMember", {
                                       user: @user_json,
@@ -92,7 +98,7 @@
                                       toggle_delete_button: true,
                                     }) %>
                         </div>
-                        <div class="col-sm profil border-left <%= @season.closing_date_for_applications >= DateTime.now ? "border-right" : "" %>" style="flex:1"->
+                        <div class="col-sm-3 profil border-left py-1 <%= @season.closing_date_for_applications >= DateTime.now ? "border-right" : "" %>" style="flex:1"->
                             <h4 class="mt-3 mb-2"> Profil </h4>
                             <% if !(m.id == @current_user.id) || @current_user.is_admin %>
                                 <%= link_to(user_path(m), class: "btn btn-primary btn-outline") do %>
@@ -106,7 +112,7 @@
                             <% end %>
                         </div>
                         <% if Season.registration_opened %>
-                          <div class="col-sm border-dark" style="flex: 1;">
+                          <div class="col-sm-2 border-dark" style="flex: 1;">
                             <h4> Activités </h4>
                             <% if !(m.id == @current_user.id) || @current_user.is_admin %>
                               <%= link_to new_application_path(m), class: "btn btn-primary" do %>
@@ -156,6 +162,10 @@
             </div>
           </div>
           <% if @current_user.is_admin or (@user.id == @current_user.id) %>
+            <div class="col-sm lienFamilial" style="flex:1">
+              <h4> Rattachement </h4>
+              <%= react_component("detachAccount", {user: attached_user.as_json(methods: %i[family_links_with_user attached_to]) }) %>
+            </div>
             <div class="col-sm profil border-left <%= @season.closing_date_for_applications >= DateTime.now ? "border-right" : "" %>" style="flex:1"->
               <h4 class="mt-3 mb-2"> Profil </h4>
               <% if !(@user.id == @current_user.id) || @current_user.is_admin %>
@@ -167,8 +177,6 @@
                 <%= link_to edit_user_path(attached_user.id), class: "btn btn-outline btn-primary" do %>
                   <i class="fas fa-edit"></i> Éditer
                 <% end %>
-
-                <%= react_component("detachAccount", {user: attached_user.as_json(methods: %i[family_links_with_user attached_to]) }) %>
               <% end %>
             </div>
             <% if Season.registration_opened %>

--- a/app/views/users/_family.html.erb
+++ b/app/views/users/_family.html.erb
@@ -50,7 +50,7 @@
                             <h3><%= m.first_name %> <b><%= m.last_name %></b></h3>
                             <span class="relation"><%= "#{m.display_family_link(@user, @season)} #{@user.genitive_first_name}" %></span><br/>
                             <% if @user.attached_accounts.where(id: m.id).any? %>
-                              <span class="relation">Compte rattaché</span>
+                              <span class="relation">Utilisateur rattaché</span>
                             <% end %>
                             <% m.telephones.each do |t| %>
                                 <p><%= t.label.nil? ? "" : t.label.capitalize %>: <%= t.number %></p>
@@ -149,7 +149,7 @@
           <div class="col-sm" style="flex:1">
             <div class="contact-info">
               <h3><%= attached_user.first_name %> <b><%= attached_user.last_name %></b></h3>
-              <span class="relation">compte rattaché</span>
+              <span class="relation">Utilisateur rattaché</span>
               <% attached_user.telephones.each do |t| %>
                 <p><%= t.label.nil? ? "" : t.label.capitalize %>: <%= t.number %></p>
               <% end %>

--- a/app/views/users/_family.html.erb
+++ b/app/views/users/_family.html.erb
@@ -168,7 +168,7 @@
             </div>
             <div class="col-sm profil border-left <%= @season.closing_date_for_applications >= DateTime.now ? "border-right" : "" %>" style="flex:1"->
               <h4 class="mt-3 mb-2"> Profil </h4>
-              <% if !(@user.id == @current_user.id) || @current_user.is_admin %>
+              <% if @user.id == @current_user.id || @current_user.is_admin || attached_user.id == @current_user %>
                 <%= link_to(user_path(attached_user), class: "btn btn-primary btn-outline") do %>
 
                   <i class="fas fa-eye"></i> Voir
@@ -182,7 +182,7 @@
             <% if Season.registration_opened %>
               <div class="col-sm border-dark" style="flex: 1;">
                 <h4> Activités </h4>
-                <% if !(@user.id == @current_user.id) || @current_user.is_admin %>
+                <% if !(attached_user.id == @current_user.id) || @current_user.is_admin %>
                   <%= link_to new_application_path(attached_user), class: "btn btn-primary" do %>
                     <i class="fas fa-graduation-cap"></i> Pré-inscrire
                   <% end %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -30,7 +30,12 @@
 
       <div class="form-group">
         <div><%= f.label :email %><span class="text-danger">*</span></div>
-        <%= f.email_field :email, autofocus: true, required: true, autocomplete: "email", class: "form-control" %>
+        <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "form-control" %>
+      </div>
+
+      <div class="form-group">
+        <div><%= f.label :compte_rattaché_à %></div>
+        <%= f.collection_select :attached_to_id, @users_to_attach, :id, :full_name, { include_blank: true }, { class: "form-control" } %>
       </div>
 
       <div class="form-group">

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -34,8 +34,12 @@
       </div>
 
       <div class="form-group">
-        <div><%= f.label :compte_rattaché_à %></div>
-        <%= f.collection_select :attached_to_id, @users_to_attach, :id, :full_name, { include_blank: true }, { class: "form-control" } %>
+        <%= react_component("common/SelectMultiple", {
+          isMulti: false,
+          title: "Compte rattaché à",
+          name: "user[attached_to_id]",
+          all_features: @users_to_attach.map { |user| ["#{user.full_name} (#{user.adherent_number})", user.id] }
+        }) %>
       </div>
 
       <div class="form-group">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -29,6 +29,10 @@
             <span class="label d-inline-block label-warning m-t-xs w-auto">Professeur</span>
           <% end %>
 
+          <% if @user.attached? %>
+            <span class="label d-inline-block m-t-xs w-auto" style="background-color: #009f9a; color: white">Compte rattaché</span>
+          <% end %>
+
           <% unless @user.activities.empty? %>
             <span class="label d-inline-block label-purple m-t-xs w-auto" >Élève</span>
           <%  end %>
@@ -37,7 +41,7 @@
             <span class="label d-inline-block label-purple m-t-xs w-auto">Adhérent</span>
           <%  end %>
 
-          <% if @adhesion.nil? && !@user.is_teacher && !@user.is_admin && @user.activities.empty? %>
+          <% if @adhesion.nil? && !@user.is_teacher && !@user.is_admin && @user.activities.empty? && !@user.attached? %>
             <span class="label d-inline-block label-primary w-auto">Utilisateur</span>
           <% end %>
         </div>
@@ -59,6 +63,14 @@
       <% end %>
 
       <div class="ibox-content">
+        <% if @user.attached? %>
+          <div class="info-group">
+            <p class="info-label">Compte rattaché à</p>
+            <%= link_to user_path(@user.attached_to) do %>
+              <%= @user.attached_to.full_name %> (<%= @user.attached_to.adherent_number %>)
+            <% end %>
+          </div>
+        <% end %>
         <%# AGE %>
         <% unless @user.birthday.nil? %>
           <div class="info-group">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -30,7 +30,7 @@
           <% end %>
 
           <% if @user.attached? %>
-            <span class="label d-inline-block m-t-xs w-auto" style="background-color: #009f9a; color: white">Compte rattaché</span>
+            <span class="label d-inline-block m-t-xs w-auto" style="background-color: #009f9a; color: white">Utilisateur rattaché</span>
           <% end %>
 
           <% unless @user.activities.empty? %>
@@ -65,7 +65,7 @@
       <div class="ibox-content">
         <% if @user.attached? %>
           <div class="info-group">
-            <p class="info-label">Compte rattaché à</p>
+            <p class="info-label">Utilisateur rattaché à</p>
             <%= link_to user_path(@user.attached_to) do %>
               <%= @user.attached_to.full_name %> (<%= @user.attached_to.adherent_number %>)
             <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -202,6 +202,7 @@ Rails.application.routes.draw do
   get "/users/:id/applications", to: "users#applications"
   get "/users/payments", to: "user_payments#show_for_current", as: :user_payments_for_current
   put "/users/:id/attach", to: "users#attach_users"
+  delete "/users/:id/detach", to: "users#detach"
   resources :users
   put "/users/:id/update_family", to: "users#update_family"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -202,7 +202,7 @@ Rails.application.routes.draw do
   get "/users/:id/applications", to: "users#applications"
   get "/users/payments", to: "user_payments#show_for_current", as: :user_payments_for_current
   put "/users/:id/attach", to: "users#attach_users"
-  delete "/users/:id/detach", to: "users#detach"
+  delete "/users/:id/detach", to: "users#detach_user"
   resources :users
   put "/users/:id/update_family", to: "users#update_family"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -201,6 +201,7 @@ Rails.application.routes.draw do
   get "/users/:id/presence_sheet/:date", to: "users#presence_sheet", as: "presence_sheet"
   get "/users/:id/applications", to: "users#applications"
   get "/users/payments", to: "user_payments#show_for_current", as: :user_payments_for_current
+  put "/users/:id/attach", to: "users#attach_users"
   resources :users
   put "/users/:id/update_family", to: "users#update_family"
 

--- a/db/migrate/20240307132834_add_attached_to_to_users.rb
+++ b/db/migrate/20240307132834_add_attached_to_to_users.rb
@@ -1,0 +1,5 @@
+class AddAttachedToToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :users, :attached_to, foreign_key: { to_table: :users }, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_02_28_184350) do
+ActiveRecord::Schema.define(version: 2024_03_07_132834) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -1242,7 +1242,9 @@ ActiveRecord::Schema.define(version: 2024_02_28_184350) do
     t.bigint "organization_id"
     t.boolean "is_creator", default: false
     t.string "identification_number"
+    t.bigint "attached_to_id"
     t.index ["address_id"], name: "index_users_on_address_id"
+    t.index ["attached_to_id"], name: "index_users_on_attached_to_id"
     t.index ["authentication_token"], name: "index_users_on_authentication_token", unique: true
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["deleted_at"], name: "index_users_on_deleted_at"
@@ -1304,4 +1306,5 @@ ActiveRecord::Schema.define(version: 2024_02_28_184350) do
   add_foreign_key "time_interval_preferences", "time_intervals"
   add_foreign_key "time_interval_preferences", "users"
   add_foreign_key "users", "organizations"
+  add_foreign_key "users", "users", column: "attached_to_id"
 end

--- a/frontend/components/AttachAccount.js
+++ b/frontend/components/AttachAccount.js
@@ -1,0 +1,151 @@
+import React, { Fragment, useEffect, useState } from "react";
+import UserSearch from "./scripts/mergeUsers/UserSearch";
+import * as api from "../tools/api";
+import _, { uniqBy } from "lodash";
+import swal from "sweetalert2";
+
+export default function AttachAccount({onSuccess})
+{
+    const [season, setSeason] = useState(null)
+    const [parentAccount, setParentAccount] = useState(null)
+    const [accountToAttach, setAccountToAttach] = useState([])
+
+    useEffect(() => {
+        api.set()
+            .success(seasons =>
+            {
+                setSeason(seasons.find(season => season.current) || seasons[0])
+            })
+            .error(() => setSeason(null))
+            .get("/seasons");
+    }, []);
+
+    if(parentAccount == null)
+    {
+        return <Fragment>
+            <h3>Sélectionner le compte de rattachement auquel associer des utilisateurs</h3>
+            <UserSearch
+                saveFirstSelect={true}
+                onSelect={user => setParentAccount(user)}
+                resetSelection={() => setParentAccount(null)}
+                season={season}
+                hideAttachedAccounts={true}
+            />
+        </Fragment>
+    }
+
+    return <Fragment>
+        <h3>Associer des utilisateurs au compte de rattachement ({`${parentAccount.first_name} ${parentAccount.last_name}`})</h3>
+
+        {accountToAttach.length > 0 && <Fragment>
+            <hr />
+
+            <h3>Utilisateurs sélectionnées</h3>
+
+            <div className="list-group">
+                {_.map(accountToAttach, (m, i) => <div
+                    key={i}
+                    className={"list-group-item row d-flex h-100"}
+                >
+                    <div className="col-sm-5 my-auto">
+                        <b>{m.first_name} {m.last_name}</b>({m.id}), Adhérent #${m.adherent_number}
+                    </div>
+
+                    <div className="col-sm-6">
+                        email (peut-être vide) :
+                        <input
+                            type="text"
+                            className="form-control"
+                            placeholder="email"
+                            value={m.email}
+                            onChange={(e) => setAccountToAttach(_.uniqBy([...accountToAttach.filter(u => u.id != m.id), {
+                                id: m.id,
+                                first_name: m.first_name,
+                                last_name: m.last_name,
+                                adherent_number: m.adherent_number,
+                                email: e.target.value
+                            }], u => u.id))
+                            }
+                        />
+                    </div>
+
+                    <div className="col-sm-1 text-right my-auto">
+                        <i className="fas fa-times pointer-event"
+                           onClick={() => setAccountToAttach(accountToAttach.filter(u => u.id !== m.id))} />
+                    </div>
+                </div>)}
+            </div>
+
+        </Fragment>}
+
+        <hr />
+
+        <UserSearch
+            saveFirstSelect={false}
+            onSelect={user => setAccountToAttach(_.uniqBy([...accountToAttach, {
+                id: user.id,
+                first_name: user.first_name,
+                last_name: user.last_name,
+                adherent_number: user.adherent_number,
+                email: user.email
+            }], u => u.id))}
+            resetSelection={() => setAccountToAttach([])}
+            season={season}
+            hideAttachedAccounts={true}
+        />
+
+        <hr />
+
+        <div className="row">
+            <div className="col text-right">
+                <button
+                    type="button"
+                    className="btn btn-success"
+                    onClick={() => {
+                        swal({
+                            type: "warning",
+                            title: "Êtes-vous sûr ?",
+                            text: "Voulez-vous vraiment attacher ces utilisateurs au compte de rattachement ? Cela va supprimer le mot de passe des comptes rattaché. Ces derniers ne pourront donc plus se connectées.",
+                            showCancelButton: true,
+                            confirmButtonText: "Oui",
+                            cancelButtonText: "Non"
+                        }).then((result) =>
+                        {
+                            if (result.value)
+                            {
+                                api.set()
+                                    .success(() => {
+                                        swal({
+                                            type: "success",
+                                            title: "Comptes attachés",
+                                            text: "Les comptes ont bien été attachés"
+                                        }).then(() => {
+                                            if(onSuccess && typeof onSuccess === "function")
+                                            {
+                                                onSuccess()
+                                            }
+
+                                            setAccountToAttach([])
+                                            setParentAccount(null)
+                                        })
+                                    })
+                                    .error(() => {
+                                        swal({
+                                            type: "error",
+                                            title: "Erreur",
+                                            text: "Une erreur est survenue lors de l'attachement des comptes"
+                                        })
+                                    })
+                                    .put(`/users/${parentAccount.id}/attach`, {
+                                        users: accountToAttach
+                                    })
+                            }
+                        });
+                    }}
+                >
+                    Attacher les comptes
+                </button>
+            </div>
+        </div>
+    </Fragment>
+}

--- a/frontend/components/UserList.js
+++ b/frontend/components/UserList.js
@@ -10,6 +10,8 @@ import ReactTableFullScreen from "./ReactTableFullScreen";
 import * as api from "../tools/api";
 import swal from "sweetalert2";
 import {post} from "../tools/api";
+import Modal from "react-modal";
+import AttachAccount from "./AttachAccount";
 
 const requestData = (pageSize, page, sorted, filtered, format) => {
     return fetch(`/users/list${format ? "." + format : ""}`, {
@@ -428,6 +430,11 @@ class UserList extends React.Component {
                         Fusionner des doublons
                     </a>
 
+                    <button className="btn btn-primary m-r" href="/users/new" onClick={() => this.setState({showAttachAccountModal: true})}>
+                        <i className="fas fa-bezier-curve"></i>&nbsp;
+                        Rattacher des utilisateurs
+                    </button>
+
 
                     <button
                         data-tippy-content="Envoyer le mail de confirmation"
@@ -469,6 +476,17 @@ class UserList extends React.Component {
                 <div className="flex flex-center-justified m-t-xs">
                     <h3>{`${this.state.total} utilisateurs au total`}</h3>
                 </div>
+
+                <Modal
+                    isOpen={this.state.showAttachAccountModal}
+                    ariaHideApp={false}
+                    onRequestClose={() => this.setState({showAttachAccountModal: false})}
+                    className="modal-lg">
+                    <AttachAccount onSucess={() => {
+                        this.setState({showAttachAccountModal: false});
+                        this.fetchData(this.state.filter)
+                    }} />
+                </Modal>
             </div>
         );
     }

--- a/frontend/components/UserList.js
+++ b/frontend/components/UserList.js
@@ -274,6 +274,16 @@ class UserList extends React.Component {
                                 Adhérent
                             </a>
                         );
+                    } else if (d.attached_to_id) {
+                        return (
+                            <a
+                                href={`/users/${d.id}`}
+                                className="badge"
+                                style={{ backgroundColor: "#009f9a", color: "white" }}
+                            >
+                                Compte rattaché
+                            </a>
+                        );
                     } else {
                         return (
                             <a
@@ -299,6 +309,7 @@ class UserList extends React.Component {
                         <option value="user">Autres</option>
                         <option value="student">Élèves</option>
                         <option value="teacher">Professeurs</option>
+                        <option value="attached">Compte rattachés</option>
                     </select>
                 ),
             },

--- a/frontend/components/UserList.js
+++ b/frontend/components/UserList.js
@@ -281,7 +281,7 @@ class UserList extends React.Component {
                                 className="badge"
                                 style={{ backgroundColor: "#009f9a", color: "white" }}
                             >
-                                Compte rattaché
+                                Utilisateur rattaché
                             </a>
                         );
                     } else {
@@ -309,7 +309,7 @@ class UserList extends React.Component {
                         <option value="user">Autres</option>
                         <option value="student">Élèves</option>
                         <option value="teacher">Professeurs</option>
-                        <option value="attached">Compte rattachés</option>
+                        <option value="attached">Utilisateur rattachés</option>
                     </select>
                 ),
             },

--- a/frontend/components/common/SelectMultiple.js
+++ b/frontend/components/common/SelectMultiple.js
@@ -103,7 +103,7 @@ export default class SelectMultiple extends React.Component
         return <div>
             <input type="hidden"
                    className="d-none none"
-                   value={this.props.isMulti ? this.state.selectedFeatures.map(f => f.value) : this.state.selectedFeatures[0].value}
+                   value={this.props.isMulti ? this.state.selectedFeatures.map(f => f.value) : (this.state.selectedFeatures[0] || {}).value}
                    name={this.props.name}
                    style={{display: "none"}} />
             <label>{this.props.title}</label>

--- a/frontend/components/detachAccount.js
+++ b/frontend/components/detachAccount.js
@@ -10,7 +10,7 @@ import Input from "./common/Input";
 import { MESSAGES } from "../tools/constants";
 import swal from "sweetalert2";
 
-export default function detachAccount({user, user_id})
+export default function detachAccount({user, user_id, from})
 {
     const [userToDetach, setUserToDetach] = useState(user);
     const [isModalOpen, setIsModalOpen] = useState(false);
@@ -41,6 +41,7 @@ export default function detachAccount({user, user_id})
         const sendData = {
             email: values.email,
             addFamilyLink: addFamilyLink,
+            from
         }
 
         if (addFamilyLink)
@@ -103,81 +104,15 @@ export default function detachAccount({user, user_id})
                                     render={Input} />
                             </div>
 
-                            <div className="col-sm">
-                                <input id="addFamilyLink" type="checkbox" onChange={e => setAddFamilyLink(e.target.checked)}/>
-                                <label htmlFor="addFamilyLink">Ajouter un lien familial</label>
-                            </div>
+                            {familyLinkCheckbox({ onClick: checked => setAddFamilyLink(checked), from })}
                         </div>
 
-                        {addFamilyLink && <div className="row">
-                            <h3>
-                                Lien familial
-                            </h3>
-
-                            <div className="col-sm">
-                                <div className="row">
-                                    <div className="col-sm-3">
-                                        <p className="h5"><b>{userToDetach.first_name} {userToDetach.last_name}</b> est
-                                        </p>
-                                    </div>
-                                    <div className="col-sm-3">
-                                        <Field
-                                            name="link"
-                                            type="select"
-                                            render={(props) => <Fragment>
-                                                <select className="form-control" {...props.input}>
-                                                    <option key={-1} />
-                                                    {props.options.map((opt, i) => (
-                                                        <option key={i} value={opt.value}>
-                                                            {opt.label}
-                                                        </option>
-                                                    ))}
-                                                </select>
-                                                {props.meta.error && props.meta.touched && <p className="help-block text-danger">{MESSAGES[props.meta.error]}</p>}
-                                            </Fragment>}
-                                            required={true}
-                                            validate={required}
-                                            options={familyLinks.map(link => ({
-                                                value: link,
-                                                label: _.capitalize(link),
-                                            }))} />
-                                    </div>
-                                    <div className="col-sm-3">
-                                        <p className="h5 text-center">de <b>{userToDetach.attached_to.first_name} {userToDetach.attached_to.last_name}</b>
-                                        </p>
-                                    </div>
-                                </div>
-
-                                <hr />
-                                <div className="row">
-                                    <h3 className="col-sm-12 m-b-sm">
-                                    Relation
-                                        avec {userToDetach.attached_to.first_name} {userToDetach.attached_to.last_name}
-                                    </h3>
-                                </div>
-
-
-                                <div className="row">
-                                <InlineYesNoRadio
-                                        label={<p>{userToDetach.attached_to.first_name} {userToDetach.attached_to.last_name} est payeur
-                                            pour {userToDetach.first_name} {userToDetach.last_name}</p>}
-                                        name="is_paying_for"
-                                        validate={required} />
-                                </div>
-
-                                <div className="row">
-                                    <InlineYesNoRadio
-                                        label={<p>{userToDetach.attached_to.first_name} {userToDetach.attached_to.last_name} est représentant légal
-                                            de {userToDetach.first_name} {userToDetach.last_name}</p>}
-                                        name="is_legal_referent"
-                                        validate={required} />
-                                </div>
-                            </div>
-                        </div>}
+                        {familyLinkForm({userToDetach, from})}
 
                         <div className="row">
                             <div className="col-sm-6">
-                                <button className="btn btn-secondary" type="button" onClick={() => setIsModalOpen(false)}>
+                                <button className="btn btn-secondary" type="button"
+                                        onClick={() => setIsModalOpen(false)}>
                                     Annuler
                                 </button>
                             </div>
@@ -194,4 +129,89 @@ export default function detachAccount({user, user_id})
 
         </Modal>
     </Fragment>
+}
+
+const familyLinkCheckbox = ({ onClick, from }) => {
+    let labelMessage = "Ajouter un lien familial";
+
+    if (from === "family_link")
+        labelMessage = "Conservé le lien familial";
+
+    return <div className="col-sm">
+        <input id="addFamilyLink" type="checkbox" onChange={e => onClick(e.target.checked)} />
+        <label htmlFor="addFamilyLink">{labelMessage}</label>
+    </div>
+}
+
+const familyLinkForm = ({userToDetach, from}) =>
+{
+    if(from !== "family_link")
+        return <Fragment>
+
+        </Fragment>
+
+    return <div className="row">
+        <h3>
+            Lien familial
+        </h3>
+
+        <div className="col-sm">
+            <div className="row">
+                <div className="col-sm-3">
+                    <p className="h5"><b>{userToDetach.first_name} {userToDetach.last_name}</b> est
+                    </p>
+                </div>
+                <div className="col-sm-3">
+                    <Field
+                        name="link"
+                        type="select"
+                        render={(props) => <Fragment>
+                            <select className="form-control" {...props.input}>
+                                <option key={-1} />
+                                {props.options.map((opt, i) => (
+                                    <option key={i} value={opt.value}>
+                                        {opt.label}
+                                    </option>
+                                ))}
+                            </select>
+                            {props.meta.error && props.meta.touched && <p className="help-block text-danger">{MESSAGES[props.meta.error]}</p>}
+                        </Fragment>}
+                        required={true}
+                        validate={required}
+                        options={familyLinks.map(link => ({
+                            value: link,
+                            label: _.capitalize(link),
+                        }))} />
+                </div>
+                <div className="col-sm-3">
+                    <p className="h5 text-center">de <b>{userToDetach.attached_to.first_name} {userToDetach.attached_to.last_name}</b></p>
+                </div>
+            </div>
+
+            <hr />
+            <div className="row">
+                <h3 className="col-sm-12 m-b-sm">
+                    Relation
+                    avec {userToDetach.attached_to.first_name} {userToDetach.attached_to.last_name}
+                </h3>
+            </div>
+
+
+            <div className="row">
+                <InlineYesNoRadio
+                    label={<p>{userToDetach.attached_to.first_name} {userToDetach.attached_to.last_name} est payeur
+                        pour {userToDetach.first_name} {userToDetach.last_name}</p>}
+                    name="is_paying_for"
+                    validate={required} />
+            </div>
+
+            <div className="row">
+                <InlineYesNoRadio
+                    label={<p>{userToDetach.attached_to.first_name} {userToDetach.attached_to.last_name} est représentant légal
+                        de {userToDetach.first_name} {userToDetach.last_name}</p>}
+                    name="is_legal_referent"
+                    validate={required} />
+            </div>
+        </div>
+    </div>
 }

--- a/frontend/components/detachAccount.js
+++ b/frontend/components/detachAccount.js
@@ -1,0 +1,197 @@
+import React, { Fragment, useEffect, useState } from "react";
+import * as api from "../tools/api";
+import Modal from "react-modal";
+import ContactForm, { familyLinks } from "./userForm/ContactForm";
+import { Field, Form } from "react-final-form";
+import { required } from "../tools/validators";
+import _ from "lodash";
+import InlineYesNoRadio from "./common/InlineYesNoRadio";
+import Input from "./common/Input";
+import { MESSAGES } from "../tools/constants";
+import swal from "sweetalert2";
+
+export default function detachAccount({user, user_id})
+{
+    const [userToDetach, setUserToDetach] = useState(user);
+    const [isModalOpen, setIsModalOpen] = useState(false);
+    const [addFamilyLink, setAddFamilyLink] = useState(false);
+
+    useEffect(() => {
+        if(!user)
+        {
+            api.set()
+                .success(u => setUserToDetach(u))
+                .error(() => setUserToDetach(null))
+                .get(`/users/${user_id}/infos`);
+        }
+    });
+
+    if(userToDetach == null)
+    {
+        return <Fragment>
+            <div className="alert alert-danger">
+                Impossible de trouver l'utilisateur
+            </div>
+        </Fragment>
+    }
+
+    function onSubmit(values)
+    {
+
+        const sendData = {
+            email: values.email,
+            addFamilyLink: addFamilyLink,
+        }
+
+        if (addFamilyLink)
+        {
+            sendData.link = values.link;
+            sendData.is_paying_for = values.is_paying_for;
+            sendData.is_legal_referent = values.is_legal_referent;
+        }
+
+        api.set()
+            .success(() => {
+                window.location.reload();
+            })
+            .error(err =>
+            {
+                swal({
+                    title: "Erreur",
+                    text: err.message || "Une erreur est survenue",
+                    type: "error"
+                });
+            })
+            .del(`/users/${userToDetach.id}/detach`, sendData, {});
+    }
+
+    return <Fragment>
+        <button className="btn btn-outline btn-danger m-2" onClick={() => setIsModalOpen(true)} type="button">
+            Détacher
+        </button>
+
+        <Modal
+            isOpen={isModalOpen}
+            onRequestClose={() => setIsModalOpen(false)}
+            contentLabel="Détacher le compte"
+        >
+            <h4>Voulez-vous détacher l'utilisateur {user.first_name} {user.last_name} ?</h4>
+            <p>
+                Ce dernier deviendras indépendant, c'est à dire qu'il pourras se connecter et géré son compte.
+                Il vous est cependant toujours possible de géré son compte si vous créez un lient familial avec lui.
+            </p>
+
+            <p>
+                Pour détacher un compte, vous devez lui ajouter une adresse email (si il n'en a pas déjà une). C'est à cet adresse que le lien lui permettant de se connecter sera envoyé. <br/>
+                P.S: ce nouvel email ne doit pas être déjà utilisé par un autre utilisateur.
+            </p>
+
+            <Form
+                onSubmit={onSubmit}
+                initialValues={{email: userToDetach.email}}
+                >
+                {({handleSubmit, form}) => {
+
+                    return <form onSubmit={handleSubmit}>
+                        <div className="row">
+                            <div className="col-sm">
+                                <label>email</label>
+                                <Field
+                                    name="email"
+                                    type="text"
+                                    validate={required}
+                                    render={Input} />
+                            </div>
+
+                            <div className="col-sm">
+                                <input id="addFamilyLink" type="checkbox" onChange={e => setAddFamilyLink(e.target.checked)}/>
+                                <label htmlFor="addFamilyLink">Ajouter un lien familial</label>
+                            </div>
+                        </div>
+
+                        {addFamilyLink && <div className="row">
+                            <h3>
+                                Lien familial
+                            </h3>
+
+                            <div className="col-sm">
+                                <div className="row">
+                                    <div className="col-sm-3">
+                                        <p className="h5"><b>{userToDetach.first_name} {userToDetach.last_name}</b> est
+                                        </p>
+                                    </div>
+                                    <div className="col-sm-3">
+                                        <Field
+                                            name="link"
+                                            type="select"
+                                            render={(props) => <Fragment>
+                                                <select className="form-control" {...props.input}>
+                                                    <option key={-1} />
+                                                    {props.options.map((opt, i) => (
+                                                        <option key={i} value={opt.value}>
+                                                            {opt.label}
+                                                        </option>
+                                                    ))}
+                                                </select>
+                                                {props.meta.error && props.meta.touched && <p className="help-block text-danger">{MESSAGES[props.meta.error]}</p>}
+                                            </Fragment>}
+                                            required={true}
+                                            validate={required}
+                                            options={familyLinks.map(link => ({
+                                                value: link,
+                                                label: _.capitalize(link),
+                                            }))} />
+                                    </div>
+                                    <div className="col-sm-3">
+                                        <p className="h5 text-center">de <b>{userToDetach.attached_to.first_name} {userToDetach.attached_to.last_name}</b>
+                                        </p>
+                                    </div>
+                                </div>
+
+                                <hr />
+                                <div className="row">
+                                    <h3 className="col-sm-12 m-b-sm">
+                                    Relation
+                                        avec {userToDetach.attached_to.first_name} {userToDetach.attached_to.last_name}
+                                    </h3>
+                                </div>
+
+
+                                <div className="row">
+                                <InlineYesNoRadio
+                                        label={<p>{userToDetach.attached_to.first_name} {userToDetach.attached_to.last_name} est payeur
+                                            pour {userToDetach.first_name} {userToDetach.last_name}</p>}
+                                        name="is_paying_for"
+                                        validate={required} />
+                                </div>
+
+                                <div className="row">
+                                    <InlineYesNoRadio
+                                        label={<p>{userToDetach.attached_to.first_name} {userToDetach.attached_to.last_name} est représentant légal
+                                            de {userToDetach.first_name} {userToDetach.last_name}</p>}
+                                        name="is_legal_referent"
+                                        validate={required} />
+                                </div>
+                            </div>
+                        </div>}
+
+                        <div className="row">
+                            <div className="col-sm-6">
+                                <button className="btn btn-secondary" type="button" onClick={() => setIsModalOpen(false)}>
+                                    Annuler
+                                </button>
+                            </div>
+
+                            <div className="col-sm-6">
+                                <button className="btn btn-danger" type="submit">
+                                    Détacher
+                                </button>
+                            </div>
+                        </div>
+                    </form>
+                }}
+            </Form>
+
+        </Modal>
+    </Fragment>
+}

--- a/frontend/components/detachAccount.js
+++ b/frontend/components/detachAccount.js
@@ -78,13 +78,13 @@ export default function detachAccount({user, user_id, from})
         >
             <h4>Voulez-vous détacher l'utilisateur {user.first_name} {user.last_name} ?</h4>
             <p>
-                Ce dernier deviendras indépendant, c'est à dire qu'il pourras se connecter et géré son compte.
-                Il vous est cependant toujours possible de géré son compte si vous créez un lient familial avec lui.
+                Ce dernier deviendra indépendant, c'est à dire qu'il pourra se connecter et gérer son compte.
+                Il vous est cependant toujours possible de gérer son compte si vous créez un lien familial avec lui.
             </p>
 
             <p>
-                Pour détacher un compte, vous devez lui ajouter une adresse email (si il n'en a pas déjà une). C'est à cet adresse que le lien lui permettant de se connecter sera envoyé. <br/>
-                P.S: ce nouvel email ne doit pas être déjà utilisé par un autre utilisateur.
+                Pour détacher un compte, vous devez lui ajouter une adresse email (si il n'en a pas déjà une). C'est à cette adresse que sera envoyé le lien lui permettant de se connecter.
+                NB : ce nouvel email ne doit pas être déjà affecté à un autre utilisateur.
             </p>
 
             <Form
@@ -135,7 +135,7 @@ const familyLinkCheckbox = ({ onClick, from }) => {
     let labelMessage = "Ajouter un lien familial";
 
     if (from === "family_link")
-        labelMessage = "Conservé le lien familial";
+        labelMessage = "Conserver le lien familial";
 
     return <div className="col-sm">
         <input id="addFamilyLink" type="checkbox" onChange={e => onClick(e.target.checked)} />

--- a/frontend/components/detachAccount.js
+++ b/frontend/components/detachAccount.js
@@ -107,7 +107,7 @@ export default function detachAccount({user, user_id, from})
                             {familyLinkCheckbox({ onClick: checked => setAddFamilyLink(checked), from })}
                         </div>
 
-                        {familyLinkForm({userToDetach, from})}
+                        {familyLinkForm({userToDetach, from, addFamilyLink})}
 
                         <div className="row">
                             <div className="col-sm-6">
@@ -143,9 +143,9 @@ const familyLinkCheckbox = ({ onClick, from }) => {
     </div>
 }
 
-const familyLinkForm = ({userToDetach, from}) =>
+const familyLinkForm = ({userToDetach, from, addFamilyLink}) =>
 {
-    if(from !== "family_link")
+    if(from === "family_link" || !addFamilyLink)
         return <Fragment>
 
         </Fragment>

--- a/frontend/components/scripts/mergeUsers/UserSearch.js
+++ b/frontend/components/scripts/mergeUsers/UserSearch.js
@@ -65,6 +65,7 @@ class UserSearch extends React.PureComponent {
                             first_name: this.state.first_name,
                             last_name: this.state.last_name,
                             season_id: this.props.season.id,
+                            hideAttachedAccounts: this.props.hideAttachedAccounts
                         }
                     );
 

--- a/frontend/components/userForm/ContactForm.js
+++ b/frontend/components/userForm/ContactForm.js
@@ -2,7 +2,7 @@ import React from "react";
 import { Form, Field, FormSpy } from "react-final-form";
 import arrayMutators from "final-form-arrays";
 import Switch from "react-switch";
-import _ from "lodash";
+import _, { values } from "lodash";
 import moment from "moment";
 
 import GeneralInfos from "./GeneralInfos";
@@ -14,6 +14,7 @@ import { required } from "../../tools/validators";
 import { fullname, toLocaleDate, toDate } from "../../tools/format";
 import { changeUser, selectPhoneType, changeRelationshipDirection } from "../../tools/mutators";
 import InlineYesNoRadio from "../common/InlineYesNoRadio";
+import Checkbox from "../common/Checkbox";
 
 const familyLinks = [
     "père",
@@ -55,6 +56,7 @@ class ContactForm extends React.PureComponent {
             last_name: props.initialValues.last_name,
             birthday: props.initialValues.birthday,
             is_inverse: props.initialValues.is_inverse,
+            is_attached: props.initialValues.is_attached,
         };
     }
 
@@ -115,13 +117,17 @@ class ContactForm extends React.PureComponent {
     }
 
     validateUserMatch() {
+        const selectedUser = this.state.suggestedUsers[this.state.selectedUserMatch];
+
         this.mutators.changeUser({
-            ...this.state.suggestedUsers[this.state.selectedUserMatch],
+            ...selectedUser,
             is_inverse: this.state.is_inverse,
+            is_attached: false
         });
         this.setState({
             isUserSearchOver: true,
             suggestedUsers: null,
+            is_attached: false,
         });
     }
 
@@ -218,6 +224,9 @@ class ContactForm extends React.PureComponent {
                     {({ handleSubmit, form }) => {
                         this.mutators = form.mutators
 
+                        console.log("form.getState().values", form.getState().values)
+                        console.log("mutators", form.mutators)
+
                         return <form onSubmit={handleSubmit} className="user-form">
                             <FormSpy
                                 subscription={{ values: true }}
@@ -227,6 +236,27 @@ class ContactForm extends React.PureComponent {
                                 ignoreValidate={false}
                                 // displayGender
                                 displayBirthday />
+
+                            { user_linked && !form.getState().values.id && <div>
+                                <Checkbox
+                                    name="is_attached"
+                                    id="is_attached"
+                                    label={`"Est rattaché à ${user_linked.first_name} ${user_linked.last_name}`}
+                                    input={{
+                                        value: this.state.is_attached,
+                                        onChange: (e) => {
+                                            this.setState({ is_attached: e.target.checked});
+                                            this.mutators.changeUser({
+                                                ...this.props.initialValues,
+                                                first_name: this.state.first_name,
+                                                last_name: this.state.last_name,
+                                                birthday: this.state.birthday,
+                                                is_attached: e.target.checked,
+                                            });
+                                        }
+                                    }} />
+                            </div>}
+
                             <hr />
 
                             {

--- a/frontend/components/userForm/ContactForm.js
+++ b/frontend/components/userForm/ContactForm.js
@@ -131,13 +131,14 @@ class ContactForm extends React.PureComponent {
         });
     }
 
-    disabledUserSearch() {
-        this.props.initialValues.first_name = this.state.first_name;
-        this.props.initialValues.last_name = this.state.last_name;
-        this.props.initialValues.birthday = this.state.birthday;
-
+    disabledUserSearch()
+    {
         this.mutators.changeUser({
             ...this.props.initialValues,
+            first_name: this.state.first_name,
+            last_name: this.state.last_name,
+            birthday: this.state.birthday,
+            is_attached: this.state.is_attached,
         })
         this.setState({ isUserSearchOver: true });
     }
@@ -225,7 +226,6 @@ class ContactForm extends React.PureComponent {
                         this.mutators = form.mutators
 
                         console.log("form.getState().values", form.getState().values)
-                        console.log("mutators", form.mutators)
 
                         return <form onSubmit={handleSubmit} className="user-form">
                             <FormSpy

--- a/frontend/components/userForm/ContactForm.js
+++ b/frontend/components/userForm/ContactForm.js
@@ -225,8 +225,6 @@ class ContactForm extends React.PureComponent {
                     {({ handleSubmit, form }) => {
                         this.mutators = form.mutators
 
-                        console.log("form.getState().values", form.getState().values)
-
                         return <form onSubmit={handleSubmit} className="user-form">
                             <FormSpy
                                 subscription={{ values: true }}

--- a/frontend/components/userForm/ContactForm.js
+++ b/frontend/components/userForm/ContactForm.js
@@ -138,9 +138,9 @@ class ContactForm extends React.PureComponent {
             first_name: this.state.first_name,
             last_name: this.state.last_name,
             birthday: this.state.birthday,
-            is_attached: this.state.is_attached,
+            is_attached: true, //this.state.is_attached, // 12/03/24 ==> attached by default if no user match
         })
-        this.setState({ isUserSearchOver: true });
+        this.setState({ isUserSearchOver: true, is_attached: true });
     }
 
     render() {
@@ -237,7 +237,7 @@ class ContactForm extends React.PureComponent {
                                 // displayGender
                                 displayBirthday />
 
-                            { user_linked && !form.getState().values.id && <div>
+                            {/* user_linked && !form.getState().values.id && <div>
                                 <Checkbox
                                     name="is_attached"
                                     id="is_attached"
@@ -255,7 +255,7 @@ class ContactForm extends React.PureComponent {
                                             });
                                         }
                                     }} />
-                            </div>}
+                            </div>*/}
 
                             <hr />
 

--- a/frontend/components/userForm/ContactForm.js
+++ b/frontend/components/userForm/ContactForm.js
@@ -16,7 +16,7 @@ import { changeUser, selectPhoneType, changeRelationshipDirection } from "../../
 import InlineYesNoRadio from "../common/InlineYesNoRadio";
 import Checkbox from "../common/Checkbox";
 
-const familyLinks = [
+export const familyLinks = [
     "père",
     "mère",
     "grand-père",

--- a/frontend/components/userForm/ContactInfos.js
+++ b/frontend/components/userForm/ContactInfos.js
@@ -127,7 +127,7 @@ class ContactInfos extends React.PureComponent {
                         type="email"
                         render={Input}
                         validate={!ignoreValidate && required}
-                        required={!ignoreValidate}
+                        required={!currentUser.is_attached && !ignoreValidate}
                     />
                 </div>
 

--- a/frontend/components/userForm/HandleFamilyMember.js
+++ b/frontend/components/userForm/HandleFamilyMember.js
@@ -23,10 +23,13 @@ class HandleFamilyMember extends React.Component {
         let url = "/users/"+this.props.user.id+"/update_family"
         let user = this.props.user;
         let {familyMember} = this.props
+
         user.family = [{
             ...values,
             initial_is_inverse: familyMember && familyMember.is_inverse,
+            attach_to_user: values.is_attached
         }];
+
         api.put(url,{
             user: user,
             has_mdp : true,
@@ -117,12 +120,13 @@ class HandleFamilyMember extends React.Component {
             toggle_edit_buton,
             toggle_delete_button,
         } = this.props
-        const formattedInitialValues = familyMember ? {...familyMember}
+        const formattedInitialValues = familyMember ? {...familyMember, is_attached: !!familyMember.attached_to_id}
             : {
                 addresses: user.addresses,
                 telephones: user.telephones,
                 email: user.email,
                 is_inverse: true,
+                is_attached: !!user.attached_to_id
             }
         
         let user_fname, user_lname, member_fname, member_lname;

--- a/frontend/packs/application.scss
+++ b/frontend/packs/application.scss
@@ -1387,7 +1387,7 @@ body {
     display: flex;
     flex: auto;
     align-items: center;
-    padding: 20px;
+    padding: 20px 15px 20px 15px;
     margin: 0 20px 20px 0;
     border-radius: 5px;
     background: white;


### PR DESCRIPTION
- Un utilisateur, dit "rattaché" peut être rattaché à un compte utilisateur, dit "principal" (compte utilisateur principal = compte de rattachement)
- Un utilisateur "rattaché" ne peut être rattaché qu'à un seul compte "principal"
- Un utilisateur "rattaché" n'a pas de compte (il ne peut pas se connecter)
- L'utilisateur "rattaché" peut avoir une adresse email ou ne pas en avoir en propre : dans ce cas, il "bénéficie" de l'adresse du compte "principal" au sens où, si on doit lui envoyer un email, ce sera avec l'adresse du compte "principal"

Dans cette proposition, un compte "principal" peut "gérer" tous les utilisateurs "rattachés" :
- Gérer leurs inscriptions (créer, annuler, modifier) :
- Modifier leur profil
- Cette notion est indépendante de la notion de payeur et de celle de responsable légal
- Cette notion est indépendante de la saison : un compte peut être rattaché ou détaché à volonté (part un admin)
- Dans le cas où on détache un utilisateur, il sera nécessaire de lui affecter une adresse email

Désormais, on refuse les doublons d'adresse e-mail

On ne prend plus en compte la notion de payeur pour définir qui gére les inscriptions.

### ATTENTION
cette feature est inclus un "breaking change". Comme dit plus haut, les adresses emails doivent être unique. Une intervention sur la base de données (script ou manuel) doit être exécuté afin de rendre les emails uniques aux seins des comptes (utilisateurs non rattachés).