### PR TITLE
ELVIS-1099--Activité-ajout-durée

### DIFF
--- a/app/controllers/activity_ref_controller.rb
+++ b/app/controllers/activity_ref_controller.rb
@@ -295,7 +295,8 @@ class ActivityRefController < ApplicationController
       :is_work_group,
       :activity_type,
       :users,
-      :nb_lessons
+      :nb_lessons,
+      :duration,
     )
   end
 end

--- a/db/migrate/20240408132303_add_duration_to_activity_refs.rb
+++ b/db/migrate/20240408132303_add_duration_to_activity_refs.rb
@@ -1,0 +1,5 @@
+class AddDurationToActivityRefs < ActiveRecord::Migration[6.1]
+  def change
+    add_column :activity_refs, :duration, :integer
+  end
+end

--- a/frontend/components/activityRef/ActivityRefBasics.js
+++ b/frontend/components/activityRef/ActivityRefBasics.js
@@ -263,16 +263,15 @@ export default class ActivityRefBasics extends React.Component {
                                 options={this.activityTypes}
                             />
                         </div>
-                        {/*<div className="col-sm-6">*/}
-                        {/*    <Field*/}
-                        {/*        label="Nombre de séances"*/}
-                        {/*        name="activityRef.nb_lessons"*/}
-                        {/*        type="number"*/}
-                        {/*        input={{placeholder: "(comme défini dans la saison)"}}*/}
-                        {/*        validate={composeValidators(mustBeIntegerOrUndefined, minValue(0))}*/}
-                        {/*        render={Input}*/}
-                        {/*    />*/}
-                        {/*</div>*/}
+                        <div className="col-sm-6">
+                            <Field
+                                label="Durée (en minutes)"
+                                name="activityRef.duration"
+                                type="number"
+                                validate={composeValidators(mustBeIntegerOrUndefined, minValue(0))}
+                                render={Input}
+                            />
+                        </div>
                     </div>
 
                     <hr/>

--- a/frontend/components/activityRef/ActivityRefContainer.js
+++ b/frontend/components/activityRef/ActivityRefContainer.js
@@ -127,7 +127,8 @@ export default class ActivityRefContainer extends React.Component {
             is_work_group: values.activityRef.is_work_group,
             instruments: this.instruments,
             users: (this.teachers || []).map(t => t.id),
-            pricings: this.state.pricingCategoriesToSave
+            pricings: this.state.pricingCategoriesToSave,
+            duration: values.activityRef.duration,
         }
 
         api


### PR DESCRIPTION
Dans la page de l'activité, ajouter un champ durée, ce champ est en minutes. Le champ n'est pas obligatoire.