### PR TITLE
Wizard, add new first step on user not selected

### DIFF
--- a/app/controllers/activities_applications_controller.rb
+++ b/app/controllers/activities_applications_controller.rb
@@ -500,7 +500,7 @@ class ActivitiesApplicationsController < ApplicationController
         else
           # @type [User] new user
           @user = if (params[:application][:infos][:id]).zero?
-                    User.new
+                    User.new(attached_to_id: params[:application][:infos][:attached_to_id])
                   else
                     User.find(params[:application][:infos][:id])
                   end

--- a/app/controllers/activities_applications_controller.rb
+++ b/app/controllers/activities_applications_controller.rb
@@ -552,15 +552,6 @@ class ActivitiesApplicationsController < ApplicationController
         # enregistrement des disponibilités de l'élève
         @user.planning.update_intervals(params[:application][:intervals], season.id)
 
-        # enregistrement des consentements de l'élève
-        params.dig(:application, :infos, :consent_docs)&.each do |doc|
-
-          consentement = @user.consent_document_users.find_or_create_by(consent_document_id: "#{doc[0]}".gsub("id_", ""))
-
-          consentement.has_consented = doc[1][:agreement]
-          consentement.save!
-        end
-
         # mise à jour de l'indicateur de paiement
         payers = params.dig(:application, :infos, :payers)
         if payers
@@ -569,6 +560,15 @@ class ActivitiesApplicationsController < ApplicationController
 
         # @user.skip_confirmation_notification!
         @user.save!
+
+        # enregistrement des consentements de l'élève
+        params.dig(:application, :infos, :consent_docs)&.each do |doc|
+
+          consentement = @user.consent_document_users.find_or_create_by(consent_document_id: "#{doc[0]}".gsub("id_", ""))
+
+          consentement.has_consented = doc[1][:agreement]
+          consentement.save!
+        end
 
         family_links_with_user = params.dig(:application, :infos, :family_links_with_user)
 

--- a/app/mailers/liquid_drops/json_drop.rb
+++ b/app/mailers/liquid_drops/json_drop.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class LiquidDrops::JsonDrop < Liquid::Drop
+
+  def initialize(json)
+    raise ArgumentError, "Expected a Hash, got: #{json.class}" unless json.is_a?(Hash)
+
+    @json = json
+
+    @json.each do |key, value|
+      if value.is_a?(Hash)
+        define_singleton_method(key) { LiquidDrops::JsonDrop.new(value) }
+      else
+        define_singleton_method(key) { value }
+      end
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -980,6 +980,13 @@ class User < ApplicationRecord
     end
   end
 
+  def availabilities(season = Season.current_apps_season)
+    planning
+      &.time_intervals
+      &.where(is_validated: false)
+      &.for_season(season)
+  end
+
   private
 
   def ensure_attached_account_has_no_password

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -983,6 +983,7 @@ class User < ApplicationRecord
   def availabilities(season = Season.current_apps_season)
     planning
       &.time_intervals
+      &.where(kind: "p")
       &.where(is_validated: false)
       &.for_season(season)
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -339,6 +339,7 @@ Rails.application.routes.draw do
   get "/plannings/availabilities", to: "planning#show_availabilities", as: :availabilities_portal
   get "/plannings/availabilities/:id(/:date)", to: "planning#show_availabilities_for_date", as: :availabilities_planning
   patch "/plannings/availabilities/:id", to: "planning#update_availabilities"
+  patch "/plannings/availabilities/:id/can_update", to: "planning#can_update_availabilities"
   post "/plannings/availabilities/:id/copy", to: "planning#copy_availabilities", as: :copy_planning
   get "/plannings/conflict/:conflict_id", to: "planning#show_for_conflict"
   get "/plannings/all_rooms", to: "planning#show_all_rooms"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -233,6 +233,7 @@ Rails.application.routes.draw do
   post "/users/search_for_admin", to: "users#search_for_admin"
   post "/users/:id/family_links_with_user", to: "users#get_family_links_with_user"
   post "/users/list", to: "users#list"
+  get "/users/:user_id/family", to: "users#family"
    # Utilisé pour peupler un select
   post "/users/simple_list", to: "users#simple_list"
   post "/users/:id/absences_list", to: "users#list_abscences"

--- a/frontend/components/activityApplications/TimePreferencesStep.js
+++ b/frontend/components/activityApplications/TimePreferencesStep.js
@@ -49,6 +49,7 @@ export default function TimePreferencesStep({
                 locked={false}
                 kinds={["p"]}
                 forSeason
+                disableLiveReload={true}
                 planningId={planningId}
                 onAdd={onAvailabilityAdd}
                 onDelete={onAvailabilityDelete}
@@ -77,6 +78,7 @@ export default function TimePreferencesStep({
                     locked={false}
                     kinds={["p"]}
                     forSeason
+                    disableLiveReload={true}
                     planningId={planningId}
                     onAdd={onAvailabilityAdd}
                     onDelete={onAvailabilityDelete}

--- a/frontend/components/activityApplications/Wizard.js
+++ b/frontend/components/activityApplications/Wizard.js
@@ -691,7 +691,7 @@ class Wizard extends React.Component {
             !this.props.preApplicationActivity && (this.props.preSelectedUser.id === this.props.user.id) && {
                 name: "Choisir un utilisateur",
                 component: (
-                    this.props.currentUserIsAdmin && false ? <UserSearch
+                    this.props.currentUserIsAdmin ? <UserSearch
                         user={this.props.user}
                         onSelect={this.handleSelectUser.bind(this)}
                         season={this.state.season}

--- a/frontend/components/activityApplications/Wizard.js
+++ b/frontend/components/activityApplications/Wizard.js
@@ -28,6 +28,7 @@ import {PRE_APPLICATION_ACTIONS} from "../../tools/constants";
 import Select from "react-select";
 import Swal from 'sweetalert2'
 import WrappedPayerPaymentTerms from "../WrappedPayerPaymentTerms";
+import WizardUserSelectMember from "./WizardUserSelectMember";
 
 const ALREADY_PRACTICED_INSTRUMENT_QUESTION_NAME =
     "already_practiced_instrument";
@@ -687,14 +688,19 @@ class Wizard extends React.Component {
         const activityChoiceActionTypes = [PRE_APPLICATION_ACTIONS.PURSUE_CHILDHOOD, PRE_APPLICATION_ACTIONS.NEW, PRE_APPLICATION_ACTIONS.RENEW];
 
         const steps = [
-            this.props.currentUserIsAdmin && !this.props.preApplicationActivity && (this.props.preSelectedUser.id === this.props.user.id) && {
+            !this.props.preApplicationActivity && (this.props.preSelectedUser.id === this.props.user.id) && {
                 name: "Choisir un utilisateur",
                 component: (
-                    <UserSearch
+                    this.props.currentUserIsAdmin && false ? <UserSearch
                         user={this.props.user}
                         onSelect={this.handleSelectUser.bind(this)}
                         season={this.state.season}
-                    />
+                    /> :
+                        <WizardUserSelectMember
+                            user={this.props.user}
+                            onSelect={this.handleSelectUser.bind(this)}
+                            season={this.state.season}
+                        />
                 ),
             },
             {

--- a/frontend/components/activityApplications/WizardUserSelectMember.js
+++ b/frontend/components/activityApplications/WizardUserSelectMember.js
@@ -171,7 +171,7 @@ export default class WizardUserSelectMember extends React.Component
 
         const virtualFamilyLinks = members.filter(m => m.id && m.id !== (members[selected] || {}).id).map(m =>
         {
-            const familyLinkToUse = ((members[selected] || {}).family_links_with_user || []).find(fl => fl.id === m.id);
+            const familyLinkToUse = ((members[selected] || {}).family_links_with_user || []).find(fl => fl.member_id === m.id);
 
             return {
                 id: m.id,
@@ -263,13 +263,13 @@ export default class WizardUserSelectMember extends React.Component
                                         members: members.map((m, i) => i === selected ? {
                                             ...m,
                                             family_links_with_user: [
-                                                ...m.family_links_with_user.filter(fl => !values.map(v => v.value).includes(fl.id)).map(fl => ({...fl, is_legal_referent: false})),
+                                                ...m.family_links_with_user.filter(fl => !values.map(v => v.value).includes(fl.member_id)).map(fl => ({...fl, is_legal_referent: false})),
                                                 ...values.map(v =>
                                                 {
                                                     const otherUser = members.find(member => member.id === v.value);
 
                                                     let res = {
-                                                        ...(m.family_links_with_user.find(fl => fl.id === otherUser.id) || {}),
+                                                        ...(m.family_links_with_user.find(fl => fl.member_id === otherUser.id) || {}),
                                                         is_legal_referent: true,
                                                     };
                                                     
@@ -309,12 +309,12 @@ export default class WizardUserSelectMember extends React.Component
                                         members: members.map((m, i) => i === selected ? {
                                             ...m,
                                             family_links_with_user: [
-                                                ...m.family_links_with_user.filter(fl => values.value !== fl.id).map(fl => ({...fl, is_to_call: false})),
+                                                ...m.family_links_with_user.filter(fl => values.value !== fl.member_id).map(fl => ({...fl, is_to_call: false})),
                                                 (() => {
                                                     const otherUser = members.find(member => member.id === values.value);
 
                                                     let res = {
-                                                        ...(m.family_links_with_user.find(fl => fl.id === otherUser.id) || {}),
+                                                        ...(m.family_links_with_user.find(fl => fl.member_id === otherUser.id) || {}),
                                                         is_to_call: true,
                                                     };
 
@@ -354,13 +354,13 @@ export default class WizardUserSelectMember extends React.Component
                                         members: members.map((m, i) => i === selected ? {
                                             ...m,
                                             family_links_with_user: [
-                                                ...m.family_links_with_user.filter(fl => values.value !== fl.id).map(fl => ({...fl, is_accompanying: false})),
+                                                ...m.family_links_with_user.filter(fl => values.value !== fl.member_id).map(fl => ({...fl, is_accompanying: false})),
                                                 (() =>
                                                 {
                                                     const otherUser = members.find(member => member.id === values.value);
 
                                                     let res = {
-                                                        ...(m.family_links_with_user.find(fl => fl.id === otherUser.id) || {}),
+                                                        ...(m.family_links_with_user.find(fl => fl.member_id === otherUser.id) || {}),
                                                         is_accompanying: true,
                                                     };
 

--- a/frontend/components/activityApplications/WizardUserSelectMember.js
+++ b/frontend/components/activityApplications/WizardUserSelectMember.js
@@ -1,0 +1,464 @@
+import React, { forwardRef, Fragment, useEffect, useImperativeHandle, useState } from "react";
+import * as api from "../../tools/api";
+import swal from "sweetalert2";
+import ToggleButtonGroup from "../ToggleButtonGroup";
+import _ from "lodash";
+import ContactForm from "../userForm/ContactForm";
+import Modal from "react-modal";
+import SelectMultiple from "../common/SelectMultiple";
+import CreatableSelect from "react-select/lib/Creatable";
+import { Field, Form } from "react-final-form";
+import Input from "../common/Input";
+import { required } from "../../tools/validators";
+import arrayMutators from "final-form-arrays";
+
+/**
+ * Class used because stepzilla doesn't support functional components for validation
+ * (call to isvalidated)
+ */
+export default class WizardUserSelectMember extends React.Component
+{
+    constructor(props)
+    {
+        super(props);
+
+        this.state = {
+            members: [],
+            selected: 0,
+            isModalOpen: false,
+            error: {},
+            showError: false,
+        };
+
+        this.getErrors = this.getErrors.bind(this);
+    }
+
+    componentDidMount()
+    {
+        api.set()
+            .success((data) =>
+            {
+                this.setState({ members: data });
+            })
+            .error(error =>
+            {
+                console.error(error);
+
+                swal({
+                    title: "Erreur",
+                    text: "Une erreur est survenue lors de la récupération des membres",
+                    type: "error",
+                    confirmButtonText: "Fermer",
+                });
+            })
+            .get(`/users/${this.props.user.id}/family`, { season: this.props.season.id });
+    }
+
+    componentDidUpdate(prevProps, prevState, snapshot)
+    {
+        const errors = this.getErrors();
+
+        if(!_.isEqual(errors, this.state.error))
+            this.setState({ error: errors });
+    }
+
+    onAddMember(values)
+    {
+        console.log(values);
+
+        const newMembers = _.cloneDeep(this.state.members);
+
+        newMembers.push({
+            ...values,
+            full_name: `${values.first_name} ${values.last_name}`,
+            family_links_with_user: [],
+            availabilities: [],
+            addresses: [],
+            telephones: [],
+        });
+
+        this.setState({
+            members: newMembers,
+            selected: newMembers.length - 1,
+            isModalOpen: false,
+        });
+    }
+
+    familyLinkWithUserToOption(m)
+    {
+        return {
+            value: m.id,
+            label: `${m.first_name} ${m.last_name}`,
+            is_legal_referent: m.is_legal_referent,
+            is_to_call: m.is_to_call,
+            is_accompanying: m.is_accompanying,
+        };
+    }
+
+    getErrors()
+    {
+        const error = {};
+
+        if(this.state.members.length === 0 || this.state.selected === undefined || this.state.members[this.state.selected] === undefined)
+            error.members = "Veuilez sélectionner un membre";
+
+        if(Object.keys(error).length === 0 && this.state.members[this.state.selected].id === this.props.user.id)
+            return {};
+
+        const familyMemberUserOptionForSelection = this.state.members && this.state.members.length > 0 && this.state.members[this.state.selected] ? this.state.members[this.state.selected]
+            .family_links_with_user
+            .map(this.familyLinkWithUserToOption) : [];
+
+        if(familyMemberUserOptionForSelection.filter(fl => fl.is_legal_referent).length === 0)
+            error.legal_referent = "Veuillez sélectionner un représentant légal";
+
+        if(familyMemberUserOptionForSelection.filter(fl => fl.is_to_call).length === 0)
+            error.to_call = "Veuillez sélectionner une personne à contacter";
+
+        if(familyMemberUserOptionForSelection.filter(fl => fl.is_accompanying).length === 0)
+            error.accompanying = "Veuillez sélectionner un accompagnant";
+
+        return error;
+    }
+
+    /**
+     * called by stepzilla to check if the form is validated
+     * @returns {boolean}
+     */
+    isValidated()
+    {
+        const error = this.getErrors();
+
+        if (Object.keys(error).length > 0)
+        {
+            this.setState({ error, showError: true });
+            return false;
+        }
+
+        this.props.onSelect(this.state.members[this.state.selected])
+
+        return true;
+    }
+
+    completeUserWithOther(user, otherUser)
+    {
+        user.id = otherUser.id ;
+        user.is_inverse = false ;
+        user.member_id = otherUser.id ;
+        user.first_name = otherUser.first_name ;
+        user.last_name = otherUser.last_name ;
+        user.sex = otherUser.sex ;
+        user.telephone = otherUser.telephones ;
+        user.addresses = otherUser.addresses ;
+        user.email = otherUser.email ;
+        user.birthday = otherUser.birthday ;
+    }
+
+    render()
+    {
+        const { user } = this.props;
+        const { members, selected, isModalOpen } = this.state;
+
+        const virtualFamilyLinks = members.filter(m => m.id && m.id !== (members[selected] || {}).id).map(m =>
+        {
+            const familyLinkToUse = ((members[selected] || {}).family_links_with_user || []).find(fl => fl.id === m.id);
+
+            return {
+                id: m.id,
+                first_name: m.first_name,
+                last_name: m.last_name,
+                is_legal_referent: familyLinkToUse ? familyLinkToUse.is_legal_referent : false,
+                is_to_call: familyLinkToUse ? familyLinkToUse.is_to_call : false,
+                is_accompanying: familyLinkToUse ? familyLinkToUse.is_accompanying : false,
+            }
+        }).map(this.familyLinkWithUserToOption);
+
+        return <Fragment>
+            <div className="ibox">
+                <div className="ibox-title">
+                    <div className="row">
+                        <div className="col-sm">
+                            <h3>Membre concerné</h3>
+                        </div>
+
+                        <div className="col-sm text-right">
+                            <button
+                                type="button"
+                                className="btn btn-primary"
+                                onClick={() => this.setState({ isModalOpen: true })}
+                            >
+                                <i className="fa fa-plus mr-2" /> Ajouter un membre
+                            </button>
+                        </div>
+                    </div>
+                </div>
+
+                <div className="ibox-content">
+                    <div className="row">
+                        <div className="p-sm-3 " style={{
+                            backgroundColor: "lightblue",
+                            borderRadius: "5px",
+                            border: "1px solid midnightblue",
+                            color: "midnightblue",
+                        }}>
+                            <div className="row">
+                                <div className="col-sm-1 pr-0">
+                                    <i className="fa fa-info-circle"
+                                       style={{ color: "midnightblue", fontSize: "20px" }} />
+                                </div>
+
+                                <div className="col-sm-11 pl-0">
+                                    Si le payeur n'est pas renseigné ce-dessous, ajoutez le en tant que
+                                    membre. Vous
+                                    pourrez ensuite
+                                    l'indiquer comme payeur dans l'étape du paiement.
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    {this.state.showError && this.state.error.members && <div className="row">
+                        <div className="col-sm-12">
+                            <p className="text-danger">{this.state.error.members}</p>
+                        </div>
+                    </div>}
+
+                    <div className="row">
+                        <ToggleButtonGroup
+                            maxSelected={1}
+                            childrenContent={members.map((member, i) => renderUserItem(user.id, member, i, selected === i))}
+                            selected={[selected]}
+                            onChange={selecteds => selecteds.length > 0 ? this.setState({ selected: selecteds[0] }) : 0}
+                            buttonStyles={{
+                                width: "200px",
+                                height: "200px",
+                                backgroundColor: "white",
+                                padding: "15px",
+                            }}
+                        />
+                    </div>
+
+                    {members.length > 0 && members[selected].id !== user.id && <Fragment>
+                        <div className="row mt-4">
+                            <div className="col-sm-6">
+                                <h4>Représentant légal</h4>
+                                <CreatableSelect
+                                    isMulti
+                                    options={virtualFamilyLinks}
+                                    value={
+                                        virtualFamilyLinks
+                                            .filter(fl => fl.is_legal_referent)
+                                    }
+                                    onChange={values => this.setState({
+                                        members: members.map((m, i) => i === selected ? {
+                                            ...m,
+                                            family_links_with_user: [
+                                                ...m.family_links_with_user.filter(fl => !values.map(v => v.value).includes(fl.id)).map(fl => ({...fl, is_legal_referent: false})),
+                                                ...values.map(v =>
+                                                {
+                                                    const otherUser = members.find(member => member.id === v.value);
+
+                                                    let res = {
+                                                        ...(m.family_links_with_user.find(fl => fl.id === otherUser.id) || {}),
+                                                        is_legal_referent: true,
+                                                    };
+                                                    
+                                                    if(res.member_id === undefined)
+                                                    {
+                                                        res.user_id = m.id ;
+                                                        this.completeUserWithOther(res, otherUser);
+                                                    }
+
+                                                    return res;
+                                                })
+                                            ]
+                                        } : m),
+                                    })}
+                                    isClearable={false}
+                                />
+                                {this.state.showError && this.state.error.legal_referent && <div className="row">
+                                    <div className="col-sm-12">
+                                        <p className="text-danger">{this.state.error.legal_referent}</p>
+                                    </div>
+                                </div>}
+                            </div>
+                        </div>
+
+                        <div className="row">
+                            <div className="col-sm-6">
+                                <label>Personne à contacter</label>
+
+                                <CreatableSelect
+                                    isMulti={false}
+                                    options={virtualFamilyLinks}
+                                    value={
+                                        virtualFamilyLinks
+                                            .filter(fl => fl.is_to_call)
+                                    }
+                                    onChange={values => this.setState({
+                                        members: members.map((m, i) => i === selected ? {
+                                            ...m,
+                                            family_links_with_user: [
+                                                ...m.family_links_with_user.filter(fl => values.value !== fl.id).map(fl => ({...fl, is_to_call: false})),
+                                                (() => {
+                                                    const otherUser = members.find(member => member.id === v.value);
+
+                                                    let res = {
+                                                        ...(m.family_links_with_user.find(fl => fl.id === otherUser.id) || {}),
+                                                        is_to_call: true,
+                                                    };
+
+                                                    if(res.member_id === undefined)
+                                                    {
+                                                        res.user_id = m.id ;
+                                                        this.completeUserWithOther(res, otherUser);
+                                                    }
+
+                                                    return res;
+                                                })()
+                                            ],
+                                        } : m),
+                                    })}
+                                    isClearable={false}
+                                />
+                                {this.state.showError && this.state.error.to_call && <div className="row">
+                                    <div className="col-sm-12">
+                                        <p className="text-danger">{this.state.error.to_call}</p>
+                                    </div>
+                                </div>}
+                            </div>
+                        </div>
+
+                        <div className="row">
+                            <div className="col-sm-6">
+                                <label>Accompagnant</label>
+
+                                <CreatableSelect
+                                    isMulti={false}
+                                    options={virtualFamilyLinks}
+                                    value={
+                                        virtualFamilyLinks
+                                            .filter(fl => fl.is_accompanying)
+                                    }
+                                    onChange={values => this.setState({
+                                        members: members.map((m, i) => i === selected ? {
+                                            ...m,
+                                            family_links_with_user: [
+                                                ...m.family_links_with_user.filter(fl => !values.map(v => v.value).includes(fl.id)).map(fl => ({...fl, is_accompanying: false})),
+                                                ...values.map(v =>
+                                                {
+                                                    const otherUser = members.find(member => member.id === v.value);
+
+                                                    let res = {
+                                                        ...(m.family_links_with_user.find(fl => fl.id === otherUser.id) || {}),
+                                                        is_accompanying: true,
+                                                    };
+
+                                                    if(res.member_id === undefined)
+                                                    {
+                                                        res.user_id = m.id ;
+                                                        this.completeUserWithOther(res, otherUser);
+                                                    }
+
+                                                    return res;
+                                                })
+                                            ],
+                                        } : m),
+                                    })}
+                                    isClearable={false}
+                                />
+                                {this.state.showError && this.state.error.accompanying && <div className="row">
+                                    <div className="col-sm-12">
+                                        <p className="text-danger">{this.state.error.accompanying}</p>
+                                    </div>
+                                </div>}
+                            </div>
+                        </div>
+                    </Fragment>}
+                </div>
+            </div>
+
+            <Modal
+                isOpen={isModalOpen}
+                ariaHideApp={false}
+                onRequestClose={() => this.setState({ isModalOpen: false })}
+                style={{
+                    content: {
+                        top: "5%",
+                        left: "25%",
+                        right: "25%",
+                    },
+                }}
+            >
+                <h2 className="mt-0">Ajouter un membre</h2>
+                <h4>création du lien familial du point de vue de {user.first_name} {user.last_name}</h4>
+                <ContactForm
+                    user_linked={user}
+                    current_user={user}
+                    initialValues={{}}
+                    showFamilyLinkInfos={false}
+                    onClose={() => this.setState({ isModalOpen: false })}
+                    onSubmit={this.onAddMember.bind(this)}
+                />
+            </Modal>
+        </Fragment>;
+    }
+}
+
+/**
+ * @param {number} currentUserId
+ * @param {any} user
+ * @param {number} i
+ * @param {boolean} isSelected
+ * @param {function} onClick
+ * @returns {JSX.Element}
+ */
+const renderUserItem = (currentUserId, user, i, isSelected) => <Fragment>
+    <div className="w-100 h-100">
+        <div className="row m-0">
+            <div className="col-sm-10 p-0">
+                {user.avatar ? <img
+                        src={user.avatar}
+                        className="img-fluid d-block"
+                        alt="Avatar"
+                        style={{
+                            width: "75px",
+                            height: "75px",
+                            borderRadius: "50%",
+                        }}
+                    />
+                    :
+                    <div
+                        className="img-fluid text-center d-block font-bold"
+                        style={{
+                            width: "75px",
+                            height: "75px",
+                            borderRadius: "50%",
+                            backgroundColor: "rgb(253, 214, 217)",
+                            lineHeight: "75px",
+                            fontSize: "30px",
+                            color: "rgb(247, 71, 84)",
+                        }}
+                    >
+                        {`${user.full_name}`.split(" ").map(n => n[0]).join("").toLocaleUpperCase()}
+                    </div>}
+            </div>
+
+            <div className="col-sm-2 p-0">
+                <div className="d-flex flex-end-justified">
+                    <input type="radio" checked={isSelected} readOnly={true} style={{ margin: "-5px -5px 0 0" }} />
+                </div>
+            </div>
+        </div>
+
+        <div className="row mt-3 text-left">
+            <div className="col-12 font-bold">
+                <h4 className="text-dark">{user.full_name}</h4>
+            </div>
+
+            <div className="col-12">
+                <p>{new Date(user.birthday).toLocaleDateString()}</p>
+            </div>
+        </div>
+    </div>
+</Fragment>;

--- a/frontend/components/activityApplications/WizardUserSelectMember.js
+++ b/frontend/components/activityApplications/WizardUserSelectMember.js
@@ -31,9 +31,10 @@ export default class WizardUserSelectMember extends React.Component
         };
 
         this.getErrors = this.getErrors.bind(this);
+        this.updateMembersData = this.updateMembersData.bind(this);
     }
 
-    componentDidMount()
+    updateMembersData()
     {
         api.set()
             .success((data) =>
@@ -54,12 +55,20 @@ export default class WizardUserSelectMember extends React.Component
             .get(`/users/${this.props.user.id}/family`, { season: this.props.season.id });
     }
 
+    componentDidMount()
+    {
+        this.updateMembersData();
+    }
+
     componentDidUpdate(prevProps, prevState, snapshot)
     {
         const errors = this.getErrors();
 
         if(!_.isEqual(errors, this.state.error))
             this.setState({ error: errors });
+
+        if(this.props.season.id !== prevProps.season.id)
+            this.updateMembersData();
     }
 
     onAddMember(values)

--- a/frontend/components/activityApplications/WizardUserSelectMember.js
+++ b/frontend/components/activityApplications/WizardUserSelectMember.js
@@ -301,7 +301,7 @@ export default class WizardUserSelectMember extends React.Component
                                             family_links_with_user: [
                                                 ...m.family_links_with_user.filter(fl => values.value !== fl.id).map(fl => ({...fl, is_to_call: false})),
                                                 (() => {
-                                                    const otherUser = members.find(member => member.id === v.value);
+                                                    const otherUser = members.find(member => member.id === values.value);
 
                                                     let res = {
                                                         ...(m.family_links_with_user.find(fl => fl.id === otherUser.id) || {}),
@@ -344,10 +344,10 @@ export default class WizardUserSelectMember extends React.Component
                                         members: members.map((m, i) => i === selected ? {
                                             ...m,
                                             family_links_with_user: [
-                                                ...m.family_links_with_user.filter(fl => !values.map(v => v.value).includes(fl.id)).map(fl => ({...fl, is_accompanying: false})),
-                                                ...values.map(v =>
+                                                ...m.family_links_with_user.filter(fl => values.value !== fl.id).map(fl => ({...fl, is_accompanying: false})),
+                                                (() =>
                                                 {
-                                                    const otherUser = members.find(member => member.id === v.value);
+                                                    const otherUser = members.find(member => member.id === values.value);
 
                                                     let res = {
                                                         ...(m.family_links_with_user.find(fl => fl.id === otherUser.id) || {}),
@@ -361,7 +361,7 @@ export default class WizardUserSelectMember extends React.Component
                                                     }
 
                                                     return res;
-                                                })
+                                                })()
                                             ],
                                         } : m),
                                     })}

--- a/frontend/components/activityApplications/WizardUserSelectMember.js
+++ b/frontend/components/activityApplications/WizardUserSelectMember.js
@@ -75,6 +75,7 @@ export default class WizardUserSelectMember extends React.Component
             availabilities: [],
             addresses: [],
             telephones: [],
+            attached_to_id: this.props.user.id
         });
 
         this.setState({
@@ -148,7 +149,7 @@ export default class WizardUserSelectMember extends React.Component
         user.first_name = otherUser.first_name ;
         user.last_name = otherUser.last_name ;
         user.sex = otherUser.sex ;
-        user.telephone = otherUser.telephones ;
+        user.telephones = otherUser.telephones ;
         user.addresses = otherUser.addresses ;
         user.email = otherUser.email ;
         user.birthday = otherUser.birthday ;

--- a/frontend/components/availability/AvailabilityManager.js
+++ b/frontend/components/availability/AvailabilityManager.js
@@ -49,13 +49,9 @@ class AvailabilityManager extends PureComponent {
     }
 
     handleAdd(interval) {
-        console.log("want add", interval);
         api.set()
             .before(this.toggleFetching)
             .success(data => {
-                console.log("success add ; result=", data);
-                console.log("list before=", this.state.list);
-                console.log("list after=", this.state.list.concat(data.intervals));
                 if (this.props.onAdd) {
                     this.props.onAdd(data.intervals);
                 }
@@ -66,7 +62,7 @@ class AvailabilityManager extends PureComponent {
                 });
             })
             .error(errors => this.setState({ errors, isFetching: false }))
-            .patch(addToken(`/plannings/availabilities/${this.props.planningId}`, this.props.authToken), {
+            .patch(addToken(`/plannings/availabilities/${this.props.planningId}${this.props.disableLiveReload ? "/can_update" : ""}`, this.props.authToken), {
                 ...interval,
                 season_id: this.props.seasonId,
             });
@@ -77,36 +73,53 @@ class AvailabilityManager extends PureComponent {
 
         const intervalIds = Array.isArray(ids) ? ids : [ids];
 
-        Promise.all(
-            intervalIds.map(id => api.del(addToken(`/time_intervals/${id}`, this.props.authToken)))
-        ).then(responses => {
-            // Error handling
-            const errors = [];
+        if(this.props.disableLiveReload)
+        {
             const list = [...this.state.list];
 
-            responses.forEach(resp => {
-                if (resp.error) {
-                    errors.push(resp.error);
-                } else if (resp.data) {
-                    list.splice(
-                        list.findIndex(
-                            interval => interval.id === resp.data.id
-                        ),
-                        1
-                    );
-                }
+            intervalIds.forEach(id => {
+                list.splice(
+                    list.findIndex(interval => interval.id === id),
+                    1
+                );
             });
 
-            if (errors.length) {
-                this.setState({ errors, list, isFetching: false });
-            } else {
-                if (this.props.onDelete) {
-                    this.props.onDelete(list);
-                }
+            this.props.onDelete(list);
+            this.setState({ list, isFetching: false });
+        }
+        else
+        {
+            Promise.all(
+                intervalIds.map(id => api.del(addToken(`/time_intervals/${id}`, this.props.authToken)))
+            ).then(responses => {
+                // Error handling
+                const errors = [];
+                const list = [...this.state.list];
 
-                this.setState({ list, isFetching: false });
-            }
-        });
+                responses.forEach(resp => {
+                    if (resp.error) {
+                        errors.push(resp.error);
+                    } else if (resp.data) {
+                        list.splice(
+                            list.findIndex(
+                                interval => interval.id === resp.data.id
+                            ),
+                            1
+                        );
+                    }
+                });
+
+                if (errors.length) {
+                    this.setState({ errors, list, isFetching: false });
+                } else {
+                    if (this.props.onDelete) {
+                        this.props.onDelete(list);
+                    }
+
+                    this.setState({ list, isFetching: false });
+                }
+            });
+        }
     }
 
     updateCommentIntervalId(selectedIntervalIdForComment) {
@@ -139,7 +152,7 @@ class AvailabilityManager extends PureComponent {
 
         const { list, errors, isFetching, selectedIntervalIdForComment } = this.state;
 
-        const selectedIntervalForComment = this.state.list.find(i => i.id === selectedIntervalIdForComment);
+        const selectedIntervalForComment = selectedIntervalIdForComment && this.state.list.find(i => i.id === selectedIntervalIdForComment);
         
         return (
             <Fragment>

--- a/frontend/components/userForm/UserForm.js
+++ b/frontend/components/userForm/UserForm.js
@@ -312,7 +312,7 @@ class UserForm extends React.PureComponent {
 
                                         <GeneralInfos
                                             displayBirthday
-                                            ignoreValidate={ false}
+                                            ignoreValidate={user ? user.is_admin : false}
                                             displayGender
                                             displayIdentificationNumber={this.props.displayIdentificationNumber && this.state.requireIdentificationNumber}
                                             requireIdentificationNumber={this.state.requireIdentificationNumber}

--- a/frontend/components/userForm/UserForm.js
+++ b/frontend/components/userForm/UserForm.js
@@ -313,7 +313,7 @@ class UserForm extends React.PureComponent {
 
                                         <GeneralInfos
                                             displayBirthday
-                                            ignoreValidate={user ? user.is_admin : false}
+                                            ignoreValidate={ false}
                                             displayGender
                                             displayIdentificationNumber={this.props.displayIdentificationNumber && this.state.requireIdentificationNumber}
                                             requireIdentificationNumber={this.state.requireIdentificationNumber}

--- a/frontend/packs/application.scss
+++ b/frontend/packs/application.scss
@@ -3525,3 +3525,7 @@ body {
     text-align: start;
     color: white;
 }
+
+.lighter-on-hover:hover {
+    opacity: 0.6;
+}


### PR DESCRIPTION
Lors de la première étape, l'utilisateur est invité à sélectionner la personne concerné par l'inscription sauf si un utilisateur est déjà pre-sélectionné (réinscription).

Si la personne n'existe pas il a possibilité de la créer en cliquant sur le bouton ajouter un membre. Lorsqu'il clique sur le bouton ajouter un membre, la modal du formulaire pour saisir les informations apparaît. Même formulaire que pour les coordonnées sans la mention du payeur.
L'utilisateur créer à ce moment seras automatiquement rattaché à celui actuellement connectée. Il faudras, si besoin le détacher depuis la page de profil après la création de la demande d'inscription.

Toutes les information saisie dans les différentes étapes (y compris la nouvelle étape 1) ne sont enregistrée que si l'inscription est validée à la fin du formulaire. 

Attention, les modifications des liens familiaux peuvent ne pas apparaitre tous de suite sur la page de profil. En effet, la page de profil affiche les données de la saison en cours (par exemple 2023-2024) alors que les modifications sont enregistrée sur la saison sur laquelle on s'inscrit. Généralement c'est la suivante (donc 2024-2025 dans l'exemple précedent).
