### PR TITLE
ELVIS-1161--Select-Location

### DIFF
--- a/frontend/components/planning/ActivityDetailsModal.js
+++ b/frontend/components/planning/ActivityDetailsModal.js
@@ -1545,8 +1545,18 @@ const ActivitySelection = ({
 
 const LocationSelection = ({locations, locationId, handleSelectLocation}) => {
 
-    const defaultLocation = locations.length === 1 ? locations[0].id : 0;
-
+    if (locations.length === 1) {
+        return (
+            <div>
+                <label className="control-label">
+                    Lieu
+                </label>
+                <p className="form-control-static">
+                    {locations[0].label}
+                </p>
+            </div>
+        );
+    }
 
     return (
         <form>


### PR DESCRIPTION
Lorsque l'école n'a qu'un lieu ne pas proposer de choisir le lieu mais prendre l'unique lieux par défaut et ne pas afficher le select. Lorsque les lieux sont supérieur à 1, afficher le select pour choisir le lieu.