### PR TITLE
ELVIS-1258--Templates-emails-balises

### DIFF
--- a/frontend/components/mailTemplates/MergeTags.jsx
+++ b/frontend/components/mailTemplates/MergeTags.jsx
@@ -120,11 +120,11 @@ export const ACTIVITY_INSTANCE_TAGS = {
 
 export const PAYMENT_TAGS = {
 
-    payment_schedule_id: {
-        name: "payment_schedule_id",
-        value: "{{payments.payment_schedule_id}}",
-        sample: "payment_schedule_id"
-    },
+    // payment_schedule_id: {
+    //     name: "payment_schedule_id",
+    //     value: "{{payments.payment_schedule_id}}",
+    //     sample: "payment_schedule_id"
+    // },
 
     season_label: {
         name: "Saison du paiement",
@@ -163,41 +163,41 @@ export const PAYMENT_TAGS = {
 }
 
 export const REGLEMENTS_TAGS = {
-
-    reglement_id: {
-        name: "reglement_id",
-        value: "{{reglements.reglement_id}}",
-        sample: "reglement_id"
-    },
-
-    reglement_payable_id: {
-        name: "reglement_payable_id",
-        value: "{{reglements.reglement_payable_id}}",
-        sample: "reglement_payable_id"
-    },
+    //
+    // reglement_id: {
+    //     name: "reglement_id",
+    //     value: "{{reglements.reglement_id}}",
+    //     sample: "reglement_id"
+    // },
+    //
+    // reglement_payable_id: {
+    //     name: "reglement_payable_id",
+    //     value: "{{reglements.reglement_payable_id}}",
+    //     sample: "reglement_payable_id"
+    // },
 
     reglement_reception_date: {
-        name: "reglement_reception_date",
+        name: "Date de réception du règlement",
         value: "{{reglements.reglement_reception_date}}",
-        sample: "reglement_reception_date"
+        sample: "Date de réception du règlement"
     },
 
     reglement_cashing_date: {
-        name: "reglement_cashing_date",
+        name: "Date d'encaissement du règlement",
         value: "{{reglement.['cashing_date']}}",
-        sample: "reglement_cashing_date"
+        sample: "Date d'encaissement du règlement"
     },
 
     reglement_amount: {
-        name: "reglement_amount",
+        name: "Montant du règlement",
         value: "{{reglement['amount']}}",
-        sample: "reglement_amount"
+        sample: "Montant du règlement"
     },
 
     reglement_status: {
-        name: "reglement_status",
+        name: "Statut du règlement",
         value: "{{reglement['status']}}",
-        sample: "reglement_status"
+        sample: "Statut du règlement"
     },
 
     reglementsLoop: {
@@ -218,7 +218,9 @@ export const UTILS_TAGS = {
         value: "{{school_link}}",
         sample: "Bouton vers le site de l'école"
     },
+}
 
+export const SCHOOL_LOGO_TAGS = {
     img_school_logo: {
         name: "Logo de l'école",
         value: "{{school_logo}}",

--- a/frontend/components/mailTemplates/MergeTags.jsx
+++ b/frontend/components/mailTemplates/MergeTags.jsx
@@ -12,27 +12,15 @@ export const APPLICATION_TAGS = {
     },
 
     applicationId: {
-        name: "ID de L'application",
+        name: "ID de la demande d'inscription",
         value: "{{application.id}}",
-        sample: "ID de l'application"
+        sample: "ID de la demande d'inscription"
     },
-
-    application_first_name: {
-        name: "Prénom de l'application",
-        value: "{{application.first_name}}",
-        sample: "Prénom de l'application"
-    },
-
-    application_last_name: {
-        name: "Nom de l'application",
-        value: "{{application.last_name}}",
-        sample: "Nom de l'application"
-    },
-
+    
     application_season_label: {
-        name: "Saison de l'application",
+        name: "Saison de la demande d'inscription",
         value: "{{application.season_label}}",
-        sample: "Saison de l'application"
+        sample: "Saison de la demande d'inscription"
     },
 
     application_total_all_due_payments: {

--- a/frontend/components/mailTemplates/TemplateEditor.jsx
+++ b/frontend/components/mailTemplates/TemplateEditor.jsx
@@ -4,79 +4,122 @@ import * as MergeTags from './MergeTags';
 import * as api from "../../tools/api";
 import swal from "sweetalert2";
 
-export default function TemplateEditor()  {
+export default function TemplateEditor() {
     const [mergeTags, setMergeTags] = useState(null);
     const [loading, setLoading] = useState(true);
     const [template, setTemplate] = useState(null);
     const [event, setEvent] = useState(null);
 
     const fetchData = async () => {
-        await api.set()
-            .success(res =>
-            {
-                setTemplate(res.template);
-                setEvent(res.event);
-                setLoading(false);
-            })
-            .error(res => {
-                swal("Une erreur est survenue lors de la récupération des templates", res.error, "error");
-            })
-            .get( window.location.pathname + "", {});
+        try {
+            await api.set()
+                .success(res => {
+                    setTemplate(res.template);
+                    setEvent(res.event);
+                    setLoading(false);
+                })
+                .error(res => {
+                    swal("Une erreur est survenue lors de la récupération des templates", res.error, "error");
+                })
+                .get(window.location.pathname, {});
+        } catch (error) {
+            swal("Erreur", "Impossible de récupérer les templates.", "error");
+        }
     }
 
     useEffect(() => {
-        fetchData()
-    }, [])
+        fetchData();
+    }, []);
 
     useEffect(() => {
-        if (template && template.path === 'upcoming_payment_mailer/upcoming_payment') {
-            setMergeTags({
+        if (!template) return;
+
+        const mergeTagConfig = {
+            'upcoming_payment_mailer/upcoming_payment': {
                 ...MergeTags.UTILS_TAGS,
                 ...MergeTags.APPLICATION_TAGS
-            });
-        } else {
-            setMergeTags({
-                ...MergeTags.ACTIVITY_TAGS,
-                ...MergeTags.ACTIVITY_INSTANCE_TAGS,
+            },
+            'payment_reminder_mailer/send_payment_reminder': {
                 ...MergeTags.APPLICATION_TAGS,
-                ...MergeTags.PAYMENT_TAGS,
-                ...MergeTags.REGLEMENTS_TAGS,
-                ...MergeTags.UTILS_TAGS
-            });
-        }
-    }, [event, template]);
+                ...MergeTags.PAYMENT_TAGS
+            },
+            'reglement_reminder_mailer/send_reglement_reminder': {
+                ...MergeTags.APPLICATION_TAGS,
+                ...MergeTags.REGLEMENTS_TAGS
+            },
+            'application_mailer/notify_new_application': {
+                ...MergeTags.UTILS_TAGS,
+                ...MergeTags.APPLICATION_TAGS,
+                ...MergeTags.ACTIVITY_TAGS
+            },
+            'user_cancelled_attendance_mailer/cancelled_attendance': {
+                ...MergeTags.UTILS_TAGS,
+                ...MergeTags.APPLICATION_TAGS,
+                ...MergeTags.ACTIVITY_INSTANCE_TAGS
+            },
+            'admin_cancelled_attendance_mailer/cancelled_attendance': {
+                ...MergeTags.UTILS_TAGS,
+                ...MergeTags.APPLICATION_TAGS,
+                ...MergeTags.ACTIVITY_INSTANCE_TAGS
+            },
+            'activity_assigned_mailer/activity_assigned': {
+                ...MergeTags.UTILS_TAGS,
+                ...MergeTags.APPLICATION_TAGS,
+                ...MergeTags.ACTIVITY_INSTANCE_TAGS
+            },
+            'activity_accepted_mailer/activity_accepted': {
+                ...MergeTags.UTILS_TAGS,
+                ...MergeTags.APPLICATION_TAGS,
+                ...MergeTags.ACTIVITY_INSTANCE_TAGS
+            },
+            'activity_proposed_mailer/activity_proposed': {
+                ...MergeTags.UTILS_TAGS,
+                ...MergeTags.APPLICATION_TAGS,
+                ...MergeTags.ACTIVITY_INSTANCE_TAGS
+            },
+            'adhesion_mailer/reminder_email': {
+                ...MergeTags.UTILS_TAGS,
+                ...MergeTags.APPLICATION_TAGS,
+                ...MergeTags.ACTIVITY_INSTANCE_TAGS
+            },
+        };
 
-    if (!loading) {
-        return (
-            <Fragment>
-                <div className="row wrapper border-bottom white-bg page-heading">
-                    <h1>Édition de templates</h1>
-                </div>
+        setMergeTags(mergeTagConfig[template.path] || {
+            ...MergeTags.ACTIVITY_TAGS,
+            ...MergeTags.ACTIVITY_INSTANCE_TAGS,
+            ...MergeTags.APPLICATION_TAGS,
+            ...MergeTags.PAYMENT_TAGS,
+            ...MergeTags.REGLEMENTS_TAGS,
+            ...MergeTags.UTILS_TAGS
+        });
+    }, [template]);
 
-                <div className="col-lg-12 col-sm-12">
-                    <div className="row w-100">
-                        <div className="col-12">
-                            <ElvisEditor
-                                templateId={template.path}
-                                templateBody={template.body}
-                                templateJson={template.json}
-                                mergeTags={mergeTags}
-                            />
-                        </div>
-                        <div className="text-left">
-                            <a
-                                href="/notification_templates/"
-                                className="btn btn-primary ml-4"
-                            >
-                                Revenir à la liste
-                            </a>
-                        </div>
+    if (loading) {
+        return <Fragment />;
+    }
+
+    return (
+        <Fragment>
+            <div className="row wrapper border-bottom white-bg page-heading">
+                <h1>Édition de templates</h1>
+            </div>
+            <div className="col-lg-12 col-sm-12">
+                <div className="row w-100">
+                    <div className="col-12">
+                        <ElvisEditor
+                            templateId={template.path}
+                            templateBody={template.body}
+                            templateJson={template.json}
+                            mergeTags={mergeTags}
+                        />
+                    </div>
+                    <div className="text-left">
+                        <a href="/notification_templates/" className="btn btn-primary ml-4">
+                            Revenir à la liste
+                        </a>
                     </div>
                 </div>
-            </Fragment>
-        );
-    } else {
-        return (<Fragment></Fragment>);
-    }
+            </div>
+        </Fragment>
+    );
 };
-

--- a/frontend/components/mailTemplates/TemplateEditor.jsx
+++ b/frontend/components/mailTemplates/TemplateEditor.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, Fragment } from 'react';
+import React, {useState, useEffect, Fragment} from 'react';
 import ElvisEditor from "./ElvisEditor";
 import * as MergeTags from './MergeTags';
 import * as api from "../../tools/api";
@@ -90,12 +90,13 @@ export default function TemplateEditor() {
             ...MergeTags.APPLICATION_TAGS,
             ...MergeTags.PAYMENT_TAGS,
             ...MergeTags.REGLEMENTS_TAGS,
-            ...MergeTags.UTILS_TAGS
+            ...MergeTags.UTILS_TAGS,
+            ...MergeTags.SCHOOL_LOGO_TAGS,
         });
     }, [template]);
 
     if (loading) {
-        return <Fragment />;
+        return <Fragment/>;
     }
 
     return (


### PR DESCRIPTION
Enlever les balises qui ne sont pas paramétrés.

Modifier "application" par "demande d'inscription".

Pour le template Rappel paiement ./ Rappel Règlements :

    ne pas afficher les balises : date de début de la séance, Heure du début de la séance, Heure de fin de la séance, Id de l'application, Jour de la semaine de l'activité, logo de l'école, nom du professeur, payment_schedule_id, prénom du professeur, reglement_amount, reglement_cashing_date, reglement_id, reglement_payable_id, reglement_reception_date, reglement_status

Pour le template Confirmation de demande d'inscription :

    ne pas afficher les balises : Date du paiement, logo de l'école, payment_schedule_id, reglement_amount, reglement_cashing_date, reglement_id, reglement_payable_id, reglement_reception_date, reglement_status, prix de l'actitivité, saison du paiement, statut du paiement, total des paiements dus, total des paiements dus restants.

Pour les templates activité assignée, activité acceptée, adhésion bientôt expirée, activité proposée, confirmation annulation de cours (utilisateur) et confirmation annulation de cours (administrateur) :

    ne pas afficher les balises : Date du paiement, logo de l'école, payment_schedule_id, reglement_amount, reglement_cashing_date, reglement_id, reglement_payable_id, reglement_reception_date, reglement_status, prix de l'actitivité, saison du paiement, statut du paiement, total des paiements dus, total des paiements dus restants.
