### PR TITLE
Various fixes new applications 2026

### DIFF
--- a/app/controllers/activities_applications_controller.rb
+++ b/app/controllers/activities_applications_controller.rb
@@ -1453,7 +1453,10 @@ class ActivitiesApplicationsController < ApplicationController
       end
     end
 
-    if activity_application.activity_application_status_id == ActivityApplicationStatus::CANCELED_ID
+    status_id = activity_application.activity_application_status_id
+
+    if status_id == ActivityApplicationStatus::CANCELED_ID || status_id == ActivityApplicationStatus::TREATMENT_IMPOSSIBLE_ID
+
       user = activity_application.user
       current_season = activity_application.season
 

--- a/app/controllers/activities_applications_controller.rb
+++ b/app/controllers/activities_applications_controller.rb
@@ -469,8 +469,7 @@ class ActivitiesApplicationsController < ApplicationController
 
     @adhesion_prices = AdhesionPrice.all.as_json
 
-    show_activity_choice_option = Parameter.get_value("activity_choice_step.activated")
-    @activitychoice_display_text = show_activity_choice_option ? Parameter.get_value("activity_choice_step.display_text") : ""
+    @application_messages = get_messages()
 
     @packs = Elvis::CacheUtils.cache_block_if_enabled("activity_refs_packs:season_#{Season.current.id}") do
       ActivityRefPricing
@@ -665,8 +664,7 @@ class ActivitiesApplicationsController < ApplicationController
 
     @adhesion_prices = Adhesion.all.as_json
 
-    show_activity_choice_option = Parameter.get_value("activity_choice_step.activated")
-    @activitychoice_display_text = show_activity_choice_option ? Parameter.get_value("activity_choice_step.display_text") : ""
+    @application_messages = get_messages()
   end
 
   def create
@@ -1543,6 +1541,19 @@ class ActivitiesApplicationsController < ApplicationController
     respond_to do |format|
       format.json { render json: { success: res } }
     end
+  end
+
+  def get_messages
+    application_messages = {"pricing_info_application"=>"", "availability_info_application"=>""}
+
+    application_messages.each do |label, value|
+      test = Parameter.get_value(label + ".activated")
+      if test
+        application_messages[label] = Parameter.get_value(label + ".display_text")
+      end
+    end
+
+    return application_messages
   end
 
   private

--- a/app/controllers/activities_applications_controller.rb
+++ b/app/controllers/activities_applications_controller.rb
@@ -606,9 +606,9 @@ class ActivitiesApplicationsController < ApplicationController
                             .uniq
 
     @current_user_is_admin = current_user ? current_user.is_admin : false
-    @activity_refs = display_activity_refs.flatten.sort_by(&:kind).as_json(methods: [:display_price, :display_name, :kind, :display_prices_by_season])
-    @activity_refs_childhood = display_activity_refs_childhood.flatten.as_json(methods: [:display_price, :display_name, :kind, :display_prices_by_season])
-    @all_activity_refs = ActivityRef.all.as_json(methods: [:display_price, :display_name, :kind, :display_prices_by_season])
+    @activity_refs = display_activity_refs.flatten.sort_by(&:kind).as_json(methods: [:display_price, :display_name, :kind, :display_prices_by_season, :highest_pricing])
+    @activity_refs_childhood = display_activity_refs_childhood.flatten.as_json(methods: [:display_price, :display_name, :kind, :display_prices_by_season, :highest_pricing])
+    @all_activity_refs = ActivityRef.all.as_json(methods: [:display_price, :display_name, :kind, :display_prices_by_season, :highest_pricing])
     @all_activity_ref_kinds = ActivityRefKind.all.as_json
     @activity_refs_cham = []
     @season = season.as_json({ include: :holidays })

--- a/app/controllers/activities_applications_controller.rb
+++ b/app/controllers/activities_applications_controller.rb
@@ -1453,15 +1453,32 @@ class ActivitiesApplicationsController < ApplicationController
 
     status_id = activity_application.activity_application_status_id
 
-    if status_id == ActivityApplicationStatus::CANCELED_ID || status_id == ActivityApplicationStatus::TREATMENT_IMPOSSIBLE_ID
+    adh_del_status_ids = [ActivityApplicationStatus::CANCELED_ID, ActivityApplicationStatus::TREATMENT_IMPOSSIBLE_ID]
 
-      user = activity_application.user
-      current_season = activity_application.season
+    user = activity_application.user
+    current_season = activity_application.season
 
-      active_adhesion = user.adhesions.where(season_id: current_season.id, is_active: true).first
+    active_adhesion = user.adhesions.find_by(season_id: current_season.id, is_active: true)
 
-      if active_adhesion
+    if adh_del_status_ids.include?(status_id)
+
+      # on chercher les demandes d'inscription
+      user_applications = ActivityApplication.joins(:activity_application_status)
+                                              .where(season_id: current_season.id, user_id: user.id)
+                                              .where.not(id: params[:id]) # pas celle que l'on update
+                                              .where.not(activity_application_statuses: { id: adh_del_status_ids }) # pas celles qui sont annulées ou non satisfaites
+
+
+      # si pas d'autre demande d'inscription, on supprime l'adhésion
+      if active_adhesion && (user_applications.count == 0)
         active_adhesion.destroy
+      end
+    else
+      # en cas de changement du statut de la demande pour autre chose qu'annulée ou non statisfaite, si l'adhésion n'existe pas/plus, on la (re)crée
+      unless active_adhesion
+        deleted_adhesion = Adhesion.only_deleted.find_by(season_id: current_season.id, user_id: user.id)
+
+        deleted_adhesion ? deleted_adhesion.recover : Adhesions::CreateAdhesion.new(user.id).execute
       end
     end
 

--- a/app/controllers/desired_activity_controller.rb
+++ b/app/controllers/desired_activity_controller.rb
@@ -46,14 +46,32 @@ class DesiredActivityController < ApplicationController
     def find_by_user_and_activity
         user_id     = params[:user_id]
         activity_id = params[:activity_id]
+        activity_ref_id = params[:activity_ref_id]
+        time_interval_id = params[:time_interval_id]
+
+        # utiliser l'activity_ref_id ?
 
         # On récupère la DesiredActivity, qu’elle vienne d’une inscription « active »
         # ou d’une option
+
+        # On cherche avec l'activity_id
         desired_activity = DesiredActivity
                              .joins(:activity_application)
                              .where("activity_applications.user_id = ? AND desired_activities.activity_id = ?", user_id, activity_id)
                              .first
 
+        # Si pas trouvé on cherche avec l'activity_ref_id et la saison (via le time_interval_id)
+        if desired_activity.nil? && activity_ref_id && time_interval_id
+            ti = TimeInterval.find(time_interval_id)
+            s = Season.from_interval(ti).first
+
+            desired_activity = DesiredActivity
+                                .joins(:activity_application)
+                                .where("activity_applications.user_id = ? AND desired_activities.activity_ref_id = ? AND activity_applications.season_id = ?", user_id, activity_ref_id, s.id)
+                                .first
+        end
+
+        # Si toujours pas trouvé on cherche dans les options
         if desired_activity.nil?
             option = Option.find_by(activity_id: activity_id)
             desired_activity = option&.desired_activity

--- a/app/controllers/parameters/activity_application_parameters_controller.rb
+++ b/app/controllers/parameters/activity_application_parameters_controller.rb
@@ -21,8 +21,10 @@ class Parameters::ActivityApplicationParametersController < ApplicationControlle
   end
 
   def get_application_step_parameters
-    @activated = Parameter.get_value('activity_choice_step.activated')
-    @display_text = Parameter.get_value('activity_choice_step.display_text')
+    parameter_label = params[:parameter_label]
+    
+    @activated = Parameter.get_value(parameter_label+'.activated')
+    @display_text = Parameter.get_value(parameter_label+'.display_text')
 
     respond_to do |format|
       format.json { render json: {
@@ -36,7 +38,7 @@ class Parameters::ActivityApplicationParametersController < ApplicationControlle
   end
 
   def change_activated_param
-    @activated = Parameter.find_or_create_by(label: 'activity_choice_step.activated', value_type: "boolean")
+    @activated = Parameter.find_or_create_by(label: params[:parameter_label]+'.activated', value_type: "boolean")
     @activated.update!(value: params[:activated].to_s)
 
     respond_to do |format|
@@ -48,7 +50,7 @@ class Parameters::ActivityApplicationParametersController < ApplicationControlle
   end
 
   def change_display_text_param
-    @display_text = Parameter.find_or_create_by(label: 'activity_choice_step.display_text')
+    @display_text = Parameter.find_or_create_by(label: params[:parameter_label]+'.display_text')
     @display_text.update!(value: params[:display_text])
 
   rescue StandardError => e

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -74,7 +74,7 @@ class SettingsController < ApplicationController
       setting = params[:settings] ? params[:settings].permit!.to_h : {}
       Setting.send "#{@plugin.name}=", setting
       flash[:notice] = "Mise à jour réussie"
-      redirect_to plugin_settings_path(@plugin)
+      redirect_to plugin_settings_path(name: @plugin.name)
     else
       @partial = @plugin.partial
       @settings = Setting.send "#{@plugin.name}"

--- a/app/models/activity_ref.rb
+++ b/app/models/activity_ref.rb
@@ -154,6 +154,10 @@ class ActivityRef < ApplicationRecord
     end
   end
 
+  def highest_pricing(season = Season.current_apps_season || Season.current)
+    activity_ref_pricing.for_season(season).maximum(:price)
+  end
+
   def kind
     activity_ref_kind&.name
   end

--- a/app/services/scripts/replicate_week_activities.rb
+++ b/app/services/scripts/replicate_week_activities.rb
@@ -55,6 +55,8 @@ module Scripts
             attendances_data = inst_to_dup.student_attendances.pluck(:user_id, :is_option)
             new_instance.student_attendances << attendances_data.map { |user_id, is_option| StudentAttendance.new(user_id: user_id, is_option: is_option) }
 
+            student_ids = attendances_data.map { |a| a[0] } # a[0] = user_id
+
             teacher_id = inst_to_dup.teachers_activity_instances.pick(:user_id)
             new_instance.teachers_activity_instances.new(user_id: teacher_id, is_main: true) if teacher_id
             new_instance.save!

--- a/app/views/activities_applications/new.html.erb
+++ b/app/views/activities_applications/new.html.erb
@@ -31,7 +31,7 @@
   availPaymentScheduleOptions: @avail_payment_schedule_options,
   availPaymentMethods: @avail_payment_methods,
   paymentStepDisplayText: @payment_step_display_text,
-  activityChoiceDisplayText: @activitychoice_display_text,
+  applicationMessages: @application_messages,
   packs: @packs,
   formulas: @formules,
   availabilityMessage: @availability_message

--- a/app/views/activities_applications/new_for_existing_user.html.erb
+++ b/app/views/activities_applications/new_for_existing_user.html.erb
@@ -35,7 +35,7 @@
   availPaymentScheduleOptions: @avail_payment_schedule_options,
   availPaymentMethods: @avail_payment_methods,
   paymentStepDisplayText: @payment_step_display_text,
-  activityChoiceDisplayText: @activitychoice_display_text,
+  applicationMessages: @application_messages,
   packs: @packs,
   availabilityMessage: @availability_message
 }) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,7 +24,7 @@ Rails.application.routes.draw do
     get "activity_application_parameters", to: "activity_application_parameters#index"
     post "activity_application_parameters/list_status", to: "activity_application_parameters#list_status"
 
-    get "activity_application_parameters/get_application_step_parameters", to: "activity_application_parameters#get_application_step_parameters"
+    get "activity_application_parameters/get_application_step_parameters/:parameter_label", to: "activity_application_parameters#get_application_step_parameters"
     post "activity_application_parameters/change_activated_param", to: "activity_application_parameters#change_activated_param"
     post "activity_application_parameters/change_display_text_param", to: "activity_application_parameters#change_display_text_param"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -160,7 +160,7 @@ Rails.application.routes.draw do
   # ACTIVITY APPLICATIONS
   #  =====================
   get "/applications/:id/desired_activities/:des_id/suggestions", to: "activities_applications#find_activity_suggestions"
-  get '/desired_activities/user/:user_id/activity/:activity_id', to: 'desired_activity#find_by_user_and_activity'
+  get '/desired_activities/user/:user_id/activity/:activity_id/ref/:activity_ref_id/time/:time_interval_id', to: 'desired_activity#find_by_user_and_activity'
 
   # (pour élève/admin) pour un élève déjà inscrit et possédant une préinscription, renvoie vers le Wizard
   get "/inscriptions/new/:user_id/:pre_application_activity_id/:activity_ref_id(/:action_type)",

--- a/frontend/components/PreApplication.jsx
+++ b/frontend/components/PreApplication.jsx
@@ -192,7 +192,7 @@ class PreApplication extends React.Component {
                             saison {`${moment(this.props.previous_season.start).format("YYYY")}/${moment(this.props.previous_season.end).format("YYYY")}`}
                         </h3>
                         <div className="col-sm-12 col-xl-6 p-0">
-                            <table className="table table-striped" style={{borderRadius: '12px', overflow: 'hidden'}}>
+                            <table className="table table-borderless bg-white" style={{borderRadius: '12px', overflow: 'hidden'}}>
                                 <thead>
                                 <tr style={{backgroundColor: "#00334A", color: "white"}}>
                                     <th style={{borderRadius: "12px 0 0 0"}}>Activité</th>

--- a/frontend/components/activityApplications/ActivityChoice.jsx
+++ b/frontend/components/activityApplications/ActivityChoice.jsx
@@ -52,7 +52,7 @@ const ActivityChoice = ({
                             handleRemovePack,
                             handleAddPack,
                             selectedPacks,
-                            infoText,
+                            pricingInfo,
                             selectedFormulas,
                             formulas,
                             selectedFormulaActivities,
@@ -344,20 +344,21 @@ const ActivityChoice = ({
 
     return (
         <Fragment>
-            <div>
-                {infoText && (
-                    <div className="alert alert-info col-md-8 d-inline-flex align-items-center p-1"
-                         style={{border: "1px solid #0079BF", borderRadius: "5px", color: "#0079BF"}}>
-                        <div className="col-sm-1 p-0 text-center">
+            {/*Message modifiable dans les paramètres de parcours d'inscription*/}
+            {pricingInfo && (
+                <div className="row pl-3 ml-0">
+                    <div className="alert alert-info col-12 row d-inline-flex align-items-center p-3 w-100"
+                            style={{border: "1px solid #0079BF", borderRadius: "5px", color: "#0079BF"}}>
+                        <div className="col-1 p-0 text-center">
                             <i className="fas fa-info-circle"></i>
                         </div>
                         <WysiwygViewer
-                            className="col-sm p-0"
-                            wysiwygStrData={infoText}
+                            className="col-11 p-0"
+                            wysiwygStrData={pricingInfo}
                         />
                     </div>
-                )}
-            </div>
+                </div>
+            )}
 
             <div className="row">
                 <div className="col-xs-12 col-lg-6">

--- a/frontend/components/activityApplications/SelectedActivitiesTable.jsx
+++ b/frontend/components/activityApplications/SelectedActivitiesTable.jsx
@@ -31,7 +31,7 @@ function createDisplayItems(groupedItems) {
         return {
             display_name: group[0].display_name,
             duration: group[0].duration, // all items have the same duration
-            display_price: group.reduce((total, item) => total + item.display_price, 0),
+            display_price: group.reduce((total, item) => total + (item.highest_pricing || item.display_price), 0),
             amount: group.length
         };
     });

--- a/frontend/components/activityApplications/TimePreferencesStep.jsx
+++ b/frontend/components/activityApplications/TimePreferencesStep.jsx
@@ -20,7 +20,8 @@ export default function TimePreferencesStep({
                                                 childhoodPreferences,
                                                 selectionLabels,
                                                 disableLiveReload = true,
-                                                availabilityMessage
+                                                availabilityMessage,
+                                                availabilityInfo
                                             })
 {
     const availabilityRef = useRef();
@@ -57,6 +58,7 @@ export default function TimePreferencesStep({
                 onAdd={onAvailabilityAdd}
                 onDelete={onAvailabilityDelete}
                 availabilityMessage={availabilityMessage}
+                availabilityInfo={availabilityInfo}
             />;
         case PREFERENCES_MODE:
             return <IntervalPreferencesEditor

--- a/frontend/components/activityApplications/Validation.jsx
+++ b/frontend/components/activityApplications/Validation.jsx
@@ -4,6 +4,7 @@ import TimePreferencesTable from "./TimePreferencesTable";
 import SelectedActivitiesTable from "./SelectedActivitiesTable";
 import EvaluationChoiceTable from "./EvaluationChoiceTable";
 import UserAvatar from "../UserAvatar";
+import WysiwygViewer from "../utils/WysiwygViewer";
 
 
 const moment = require("moment");
@@ -26,6 +27,7 @@ const Validation = ({
                         availPaymentMethods,
                         selectedFormulas,
                         selectedFormulaActivities,
+                        pricingInfo
                     }) => {
     const addStudents = [...additionalStudents];
 
@@ -383,7 +385,21 @@ const Validation = ({
                         </div>
                     </div>
 
-
+                    {/*Message modifiable dans les paramètres de parcours d'inscription*/}
+                    {pricingInfo && (
+                        <div className="row pl-3 ml-0 mt-3">
+                            <div className="alert alert-info col-12 row d-inline-flex align-items-center p-4 w-100"
+                                    style={{border: "1px solid #0079BF", borderRadius: "5px", color: "#0079BF"}}>
+                                <div className="col-1 p-0 text-center">
+                                    <i className="fas fa-info-circle"></i>
+                                </div>
+                                <WysiwygViewer
+                                    className="col-11 p-0"
+                                    wysiwygStrData={pricingInfo}
+                                />
+                            </div>
+                        </div>
+                    )}
 
                     {/*Disponibilités*/}
                     {showTimePreferences ? (

--- a/frontend/components/activityApplications/Validation.jsx
+++ b/frontend/components/activityApplications/Validation.jsx
@@ -171,7 +171,8 @@ const Validation = ({
     }
 
     const totalActivitiesCost = selectedActivities.reduce((total, act) => {
-        return total + (act && act.display_price ? parseFloat(act.display_price) : 0);
+        let price = act.highest_pricing || act.display_price;
+        return total + (act && price ? parseFloat(price) : 0);
     }, 0);
 
     const totalFormulasCost = application.selectedFormulas.reduce((total, formulaId) => {

--- a/frontend/components/activityApplications/Wizard.jsx
+++ b/frontend/components/activityApplications/Wizard.jsx
@@ -919,7 +919,7 @@ class Wizard extends React.Component {
                         selectedFormulaActivities={this.state.selectedFormulaActivities}
                         selectedPacks={this.state.selectedPacks}
                         validation={null}
-                        infoText={this.props.activityChoiceDisplayText}
+                        pricingInfo={this.props.applicationMessages["pricing_info_application"]}
                     />
                 ),
             },
@@ -968,6 +968,7 @@ class Wizard extends React.Component {
                             this.handleUpdateChildhoodPreferences(prefs)
                         }
                         availabilityMessage={this.props.availabilityMessage}
+                        availabilityInfo={this.props.applicationMessages["availability_info_application"]}
                     />
                 ),
             },
@@ -1054,6 +1055,7 @@ class Wizard extends React.Component {
                         selectedFormulas={this.state.selectedFormulas}
                         selectedFormulaActivities={this.state.selectedFormulaActivities}
                         formulas={this.props.formulas}
+                        pricingInfo={this.props.applicationMessages["pricing_info_application"]}
                     />
                 ),
             },

--- a/frontend/components/activityApplications/summary/Activity.jsx
+++ b/frontend/components/activityApplications/summary/Activity.jsx
@@ -37,7 +37,7 @@ const LevelCell = ({
 
         api
             .set()
-            .get(`/desired_activities/user/${user.id}/activity/${activityId}`)
+            .get(`/desired_activities/user/${user.id}/activity/${activityId}/ref/${activityRefId}/time/${timeInterval.id}`)
             .then(response => {
                 if (isMounted) {
                     const apiLevel = response?.data?.evaluation_level_ref;
@@ -82,7 +82,7 @@ const LevelCell = ({
         return () => {
             isMounted = false;
         };
-    }, [user.id, activityId, initialLevel, activityRefId, timeInterval, activityRef, seasons]);
+    }, [user.id, activityId, initialLevel, activityRefId, timeInterval, activityRef, seasons, timeInterval.id]);
 
     if (isLoading) {
         return <>Chargement...</>;

--- a/frontend/components/activityApplications/summary/Summary.jsx
+++ b/frontend/components/activityApplications/summary/Summary.jsx
@@ -133,7 +133,11 @@ class Summary extends React.Component
             return Promise.resolve(false);
         }
 
-        if (parseInt(this.state.status_id, 10) === ActivityApplicationStatus.CANCELED_ID)
+        let status_id = parseInt(this.state.status_id, 10);
+
+        let adhesion_delete_ids = [ActivityApplicationStatus.CANCELED_ID, ActivityApplicationStatus.TREATMENT_IMPOSSIBLE_ID]
+
+        if (adhesion_delete_ids.includes(status_id))
         {
             return new Promise((resolve) => {
                 swal.fire({

--- a/frontend/components/activityApplications/summary/Summary.jsx
+++ b/frontend/components/activityApplications/summary/Summary.jsx
@@ -142,7 +142,7 @@ class Summary extends React.Component
             return new Promise((resolve) => {
                 swal.fire({
                     title: 'Attention !',
-                    text: 'L\'adhésion associée va être supprimée en validant. Êtes-vous sûr de continuer ?',
+                    text: 'L\'adhésion associée sera supprimée si aucune autre inscription n\'est en cours pour cette personne. Êtes-vous sûr·e de continuer ?',
                     type: 'warning',
                     showCancelButton: true,
                     confirmButtonText: 'Oui, continuer',

--- a/frontend/components/activityItems/CurrentActivityItem.jsx
+++ b/frontend/components/activityItems/CurrentActivityItem.jsx
@@ -138,6 +138,8 @@ class CurrentActivityItem extends React.Component {
             authToken,
         } = this.props;
 
+        let inlineButton = false;
+
         let isPreapplicationEnabled = false;
         if (this.state.preApplicationActivity !== undefined) {
             isPreapplicationEnabled =
@@ -187,21 +189,27 @@ class CurrentActivityItem extends React.Component {
                 nextActivityRefKinds = nextActivityRefKinds.concat(timeslotActivities);
                 nextActivityRefKinds = _.uniqBy(nextActivityRefKinds, "id");
 
+                inlineButton = false;
+
                 actionButtons =
                     <Fragment>
-                        {StopButton}
+                        <div className="d-flex flex-column flex-space-between align-items-end">
                         {nextActivityRefKinds.map(activity =>
-                            <a
+                            <a  key={activity.to.id}
                                 href={`/inscriptions/new/${user.id}/${this.state.preApplicationActivity.id
                                 }/${activity.to.id}/${PRE_APPLICATION_ACTIONS.PURSUE_CHILDHOOD}?auth_token=${csrfToken}`}
-                                className="btn btn-info ml-2 font-weight-bold">
-                                S'inscrire à l'activité&nbsp;
-                                {activity.to.display_name}
+                                className="btn btn-info mb-2 font-weight-bold">
+                                <div className="flex-xl-row flex-lg-row flex-column">
+                                    <div className="mr-xl-2 mr-lg-2 m-0">S'inscrire à l'activité</div>
+                                    <div>{activity.to.display_name}</div>
+                                </div>
                             </a>
                         )}
-
+                        </div>
                     </Fragment>;
             } else {
+                inlineButton = true;
+
                 actionButtons =
                     <React.Fragment>
                         {StopButton}
@@ -219,7 +227,7 @@ class CurrentActivityItem extends React.Component {
 
         return (
             <React.Fragment>
-                <tr>
+                <tr className="border-top">
                     <td className="font-weight-bold" style={{color: "#00283B"}}>
                         {data.activity_ref.label}
                     </td>
@@ -227,9 +235,20 @@ class CurrentActivityItem extends React.Component {
                         {this.props.user.first_name} {this.props.user.last_name}
                     </td>
                     <td className="text-right">
-                        {actionButtons}
+                        {inlineButton ?
+                            <div>{actionButtons}</div> // actionButtons including a StopButton
+                            :
+                            <div>{StopButton}</div> // StopButton only
+                        }
                     </td>
                 </tr>
+                {!inlineButton && actionButtons ?
+                    <tr>
+                        <td colSpan="3">
+                            {actionButtons} {/* actionButtons without a StopButton (already in the tr above) */}
+                        </td>
+                    </tr>
+                :null}
 
                 <Modal
                     isOpen={this.state.isStopModalOpen}

--- a/frontend/components/availability/AvailabilityManager.jsx
+++ b/frontend/components/availability/AvailabilityManager.jsx
@@ -8,6 +8,7 @@ import {INTERVAL_KINDS} from "../../tools/constants";
 import AvailabilityCommentModal from "./AvailabilityCommentModal";
 import moment from "moment";
 import _ from "lodash";
+import WysiwygViewer from "../utils/WysiwygViewer";
 
 const kindsForSeason = [
     INTERVAL_KINDS.LESSON,
@@ -195,6 +196,22 @@ class AvailabilityManager extends PureComponent {
         return (
             <Fragment>
                 <ErrorList errors={errors}/>
+
+                {/*Message modifiable dans les paramètres de parcours d'inscription*/}
+                {this.props.availabilityInfo && (
+                    <div className="p-xs">
+                        <div className="alert alert-danger row d-inline-flex align-items-center p-3 m-0 w-100"
+                                style={{border: "1px solid #a94442", borderRadius: "5px", color: "#a94442"}}>
+                            <div className="col-1 p-0 text-center">
+                                <i className="fas fa-info-circle"></i>
+                            </div>
+                            <WysiwygViewer
+                                className="col-11 p-0"
+                                wysiwygStrData={this.props.availabilityInfo}
+                            />
+                        </div>
+                    </div>
+                )}
 
                 <div className="p-xs">
                     {!locked ? (

--- a/frontend/components/courses/LessonList.jsx
+++ b/frontend/components/courses/LessonList.jsx
@@ -1363,8 +1363,8 @@ const UserRow = ({
 
                 setActivityApplicationId(data.activity_application_id);
             })
-            .get(`/desired_activities/user/${user.id}/activity/${activity.id}`);
-    }, [user.id, activity.id]);
+            .get(`/desired_activities/user/${user.id}/activity/${activity.id}/ref/${activity.activity_ref_id}/time/${activity.time_interval_id}`);
+    }, [user.id, activity.id, activity.activity_ref_id, activity.time_interval_id]);
 
     const inscriptionUrl = activityApplicationId ? `/inscriptions/${activityApplicationId}` : "#";
 

--- a/frontend/components/parameters/ActivityApplications/ActivityApplicationsParameters.jsx
+++ b/frontend/components/parameters/ActivityApplications/ActivityApplicationsParameters.jsx
@@ -13,7 +13,20 @@ export default function ActivityApplicationsParameters() {
             <ApplicationStatusTable />,
             <ConsentDocumentsList />,
             <ApplicationParameters />,
-            <ApplicationStepParameters />
+            <div>
+                {/*Liste des messages modifiables dans les paramètres de parcours d'inscription (update or create)*/}
+                <ApplicationStepParameters
+                    key='pricing_info'
+                    parameter_label='pricing_info_application'
+                    desc='Message tarifs'
+                />
+                <hr></hr>
+                <ApplicationStepParameters
+                    key='availability_info'
+                    parameter_label='availability_info_application'
+                    desc='Message disponibilités'
+                />
+            </div>
         ]}
     />
 }

--- a/frontend/components/parameters/ActivityApplications/ApplicationStepParameters.jsx
+++ b/frontend/components/parameters/ActivityApplications/ApplicationStepParameters.jsx
@@ -5,7 +5,7 @@ import {toast} from "react-toastify";
 import {EditorState, convertToRaw, convertFromRaw, ContentState} from 'draft-js';
 import {Editor} from 'react-draft-wysiwyg';
 
-export default function ApplicationStepParameters() {
+export default function ApplicationStepParameters({parameter_label, desc}) {
     const [editorState, setEditorState] = useState(() => EditorState.createEmpty());
     const [visibilityActivated, setVisibilityActivated] = useState(false);
     const [init, setInit] = useState(true);
@@ -31,7 +31,7 @@ export default function ApplicationStepParameters() {
             .error(err => {
                 swal("Une erreur est survenue lors du chargement des paramètres du parcours d'inscription", res.error, "error");
             })
-            .get("activity_application_parameters/get_application_step_parameters", {});
+            .get(`activity_application_parameters/get_application_step_parameters/${parameter_label}`, {});
     }, []);
 
     useEffect(() => {
@@ -40,7 +40,7 @@ export default function ApplicationStepParameters() {
                 .error(res => {
                     swal("Une erreur est survenue lors de la sauvegarde des paramètres du parcours d'inscription", res.error, "error");
                 })
-                .post("activity_application_parameters/change_activated_param", {activated: visibilityActivated});
+                .post("activity_application_parameters/change_activated_param", {parameter_label: parameter_label, activated: visibilityActivated});
         }
     }, [visibilityActivated]);
 
@@ -52,30 +52,27 @@ export default function ApplicationStepParameters() {
             .error(res => {
                 swal("Une erreur est survenue lors de la sauvegarde des paramètres du parcours d'inscription", res.error, "error");
             })
-            .post("activity_application_parameters/change_display_text_param", {display_text: JSON.stringify(convertToRaw(editorState.getCurrentContent()))});
+            .post("activity_application_parameters/change_display_text_param", {parameter_label: parameter_label, display_text: JSON.stringify(convertToRaw(editorState.getCurrentContent()))});
     }
 
 
     return <div className="m-3">
         <div className="mb-5">
-            <h3>Visibilité</h3>
+            <h3>{desc}</h3>
             <div className="checkbox checkbox-primary">
                 <input
                     type="checkbox"
-                    id={"paymentScheduleOptionsActivated"}
+                    id={`${parameter_label}.paymentScheduleOptionsActivated`}
                     className=""
                     checked={visibilityActivated}
                     onChange={(e) => setVisibilityActivated(e.target.checked)}
                 />
-                <label htmlFor={"paymentScheduleOptionsActivated"}>Afficher le texte dans le parcours d'inscription.</label>
+                <label htmlFor={`${parameter_label}.paymentScheduleOptionsActivated`}>Afficher le texte</label>
             </div>
         </div>
 
         <div>
-            <h3>Choix de l'activité</h3>
             <form onSubmit={e => {e.preventDefault();onSaveDisplayText()}}>
-                <p>Editer le texte présent dans l'étape 3.</p>
-
                 <div className="form-group mb-5">
                     <Editor
                         wrapperStyle={{border: "1px solid #e7eaec", padding: "5px", borderRadius: "5px"}}
@@ -85,7 +82,7 @@ export default function ApplicationStepParameters() {
                         wrapperClassName="wrapperClassName"
                         editorClassName="editorClassName"
                         toolbar={{
-                            options: ['inline', 'blockType', 'emoji', 'list',],
+                            options: ['inline', 'blockType', 'emoji', 'list', 'link'],
                             inline: {
                                 options: ['bold', 'italic', 'underline', 'strikethrough'],
                             },


### PR DESCRIPTION
- Interface de réinscription responsive en cas de boutons multiples (ex : poursuite enfance)
- Suppression de l'adhésion si demande non satisfaite (comme pour une demande annulée) si aucune autre demande en cours + recréation de l'adhésion si demande restaurée
- Correctif d'un bug qui faisait pointer tous les élèves d'un cours vers le même profil dans la liste des cours
- Affichage en priorité du plus haut prix de la liste des prix pour une activité plutôt de de chercher le prix maximal stocké à part dans sa table (à voir pour éventuellement supprimer la table max_activity_ref_price_for_seasons)
- Changement de la gestion des messages à afficher dans le parcours d'inscription
- Correctif du slug pour la redirection après changement des paramètres d'un plugin
- Correctif du script pour répliquer les cours d'une semaine sur une plage de dates 